### PR TITLE
feat(metrics docs): add collateral generation for metrics documentation

### DIFF
--- a/collateral/cobra.go
+++ b/collateral/cobra.go
@@ -40,7 +40,6 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 				c.EmitManPages = true
 				c.EmitMarkdown = true
 				c.EmitHTMLFragmentWithFrontMatter = true
-				c.EmitMetricsHTMLFragment = true
 				c.ManPageInfo = *hdr
 			}
 
@@ -55,7 +54,6 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
 	cmd.Flags().BoolVarP(&c.EmitZshCompletion, "zsh", "", c.EmitZshCompletion, "Produce zsh completion files")
 	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
-	cmd.Flags().BoolVarP(&c.EmitMetricsHTMLFragment, "metrics_html", "", c.EmitMetricsHTMLFragment, "Produce metrics HTML documentation file")
 	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
 		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
 

--- a/collateral/cobra.go
+++ b/collateral/cobra.go
@@ -40,6 +40,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 				c.EmitManPages = true
 				c.EmitMarkdown = true
 				c.EmitHTMLFragmentWithFrontMatter = true
+				c.EmitMetricsHTMLFragment = true
 				c.ManPageInfo = *hdr
 			}
 
@@ -54,6 +55,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
 	cmd.Flags().BoolVarP(&c.EmitZshCompletion, "zsh", "", c.EmitZshCompletion, "Produce zsh completion files")
 	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
+	cmd.Flags().BoolVarP(&c.EmitMetricsHTMLFragment, "metrics_html", "", c.EmitMetricsHTMLFragment, "Produce metrics HTML documentation file")
 	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
 		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
 

--- a/collateral/control.go
+++ b/collateral/control.go
@@ -334,7 +334,7 @@ func genHTMLFragment(cmd *cobra.Command, path string) error {
 
 	g.genVars(cmd)
 	g.genAnnotations(cmd)
-	g.genMetrics(cmd)
+	g.genMetrics()
 
 	f, err := os.Create(path)
 	if err != nil {
@@ -735,7 +735,7 @@ func (g *generator) genAnnotations(root *cobra.Command) {
 	g.emit("</table>")
 }
 
-func (g *generator) genMetrics(root *cobra.Command) {
+func (g *generator) genMetrics() {
 	g.emit(`<h2 id=\"metrics\">Exported Metrics</h2>
 <table class=\"metrics\">
 <thead>

--- a/collateral/control.go
+++ b/collateral/control.go
@@ -739,17 +739,15 @@ func (g *generator) genMetrics() {
 	g.emit(`<h2 id=\"metrics\">Exported Metrics</h2>
 <table class=\"metrics\">
 <thead>
-<tr><th>Name</th><th>Type</th><th>Description</th></tr>
+<tr><th>Metric Name</th><th>Type</th><th>Description</th></tr>
 </thead>
-<tbody>
-`)
+<tbody>`)
 
 	r := metrics.NewOpenCensusRegistry()
 	for _, metric := range r.ExportedMetrics() {
-		g.emit("<tr><td>", metric.Name, "</td><td>", metric.Type, "</td><td>", metric.Description, "</td></tr>")
+		g.emit("<tr><td><code>", metric.Name, "</code></td><td><code>", metric.Type, "</code></td><td>", metric.Description, "</td></tr>")
 	}
 
 	g.emit(`</tbody>
-</table>
-`)
+</table>`)
 }

--- a/collateral/metrics/metrics.go
+++ b/collateral/metrics/metrics.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics provides utilities for generating metrics-related collateral
+// for a binary.
+package metrics
+
+// HTMLGenerator provides an interface for different metrics implementations
+// to deliver HTML presentations of the exported metrics for a binary.
+type HTMLGenerator interface {
+	// GenerateHTML produces a description of exported metrics for a binary in HTML
+	GenerateHTML() string
+}

--- a/collateral/metrics/metrics.go
+++ b/collateral/metrics/metrics.go
@@ -16,9 +16,9 @@
 // for a binary.
 package metrics
 
-// HTMLGenerator provides an interface for different metrics implementations
-// to deliver HTML presentations of the exported metrics for a binary.
-type HTMLGenerator interface {
-	// GenerateHTML produces a description of exported metrics for a binary in HTML
-	GenerateHTML() string
+// Exported contains the name, type, and description of an exported metric.
+type Exported struct {
+	Name        string
+	Type        string
+	Description string
 }

--- a/collateral/metrics/opencensus.go
+++ b/collateral/metrics/opencensus.go
@@ -1,0 +1,116 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"go.opencensus.io/stats/view"
+)
+
+const (
+	tableHeader = `<h2 id=\"metrics\">Exported Metrics</h2>
+<table class=\"metrics\">
+<thead>
+<tr><th>Name</th><th>Type</th><th>Description</th></tr>
+</thead>
+<tbody>
+`
+	tableFooter = `</tbody>
+</table>
+`
+)
+
+// openCensusHTMLGenerator implements the metrics.HTMLGenerator interface.
+// It should only be used to generate collateral for processes offline.
+// It is not suitable for production usage.
+type openCensusHTMLGenerator struct {
+	nameDescMap map[string]string
+	nameTypeMap map[string]string
+}
+
+// NewOpenCensusHTMLGenerator builds a new HTMLGenerator based on OpenCensus
+// metrics export. As part of the setup, it configures the OpenCensus mechanisms
+// for rapid reporting (1ms) and sleeps for double that period (2ms) to ensure
+// an export happens before generation.
+func NewOpenCensusHTMLGenerator() HTMLGenerator {
+	// note: only use this for collateral generation
+	// this reporting period is NOT suitable for all exporters
+	view.SetReportingPeriod(1 * time.Millisecond)
+
+	e := &openCensusHTMLGenerator{
+		nameDescMap: make(map[string]string),
+		nameTypeMap: make(map[string]string),
+	}
+	view.RegisterExporter(e)
+
+	time.Sleep(2 * time.Millisecond) // allow export to happen
+	return e
+}
+
+// ExportView implements view.Exporter
+func (e *openCensusHTMLGenerator) ExportView(d *view.Data) {
+	e.nameDescMap[d.View.Name] = d.View.Description
+	e.nameTypeMap[d.View.Name] = d.View.Aggregation.Type.String()
+}
+
+// GenerateHTML implements metrics.HTMLGenerator.
+// It emits a HTML string with all of the OpenCensus exported metrics
+// listed in a table by name, type, and description.
+func (e *openCensusHTMLGenerator) GenerateHTML() string {
+	var sb strings.Builder
+
+	sb.WriteString(tableHeader)
+
+	names := []string{}
+	for key := range e.nameDescMap {
+		names = append(names, key)
+	}
+
+	sort.Strings(names)
+
+	for _, n := range names {
+
+		var d, t string
+		if desc, ok := e.nameDescMap[n]; !ok {
+			d = "N/A"
+		} else {
+			d = desc
+		}
+
+		if kind, ok := e.nameTypeMap[n]; !ok {
+			t = view.Sum().Type.String()
+		} else {
+			t = kind
+		}
+
+		sb.WriteString("<tr><td>" + promName(n) + "</td>")
+		sb.WriteString("<td>" + t + "</td>")
+		sb.WriteString("<td>" + d + "</td></tr>\n")
+	}
+
+	sb.WriteString(tableFooter)
+
+	return sb.String()
+}
+
+var charReplacer = strings.NewReplacer("/", "_", ".", "_", " ", "_", "-", "")
+
+func promName(metricName string) string {
+	s := strings.TrimPrefix(metricName, "/")
+	return charReplacer.Replace(s)
+}

--- a/collateral/metrics/opencensus_test.go
+++ b/collateral/metrics/opencensus_test.go
@@ -15,6 +15,7 @@
 package metrics_test
 
 import (
+	"reflect"
 	"testing"
 
 	"go.opencensus.io/stats"
@@ -24,34 +25,16 @@ import (
 	"istio.io/pkg/collateral/metrics"
 )
 
-func TestGenerateHTML(t *testing.T) {
+func TestExportedMetrics(t *testing.T) {
 	registerViews()
-	e := metrics.NewOpenCensusHTMLGenerator()
-
-	if got := e.GenerateHTML(); got != expected {
-		t.Errorf("GenerateHTML() = %v, want %v", got, expected)
+	r := metrics.NewOpenCensusRegistry()
+	if got := r.ExportedMetrics(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ExportedMetrics() = %v, want %v", got, want)
 	}
 }
 
 // stolen shamelessly from mixer pkgs in istio/istio for testing purposes
 var (
-	expected = `<h2 id=\"metrics\">Exported Metrics</h2>
-<table class=\"metrics\">
-<thead>
-<tr><th>Name</th><th>Type</th><th>Description</th></tr>
-</thead>
-<tbody>
-<tr><td>mixer_config_adapter_info_configs_total</td><td>LastValue</td><td>The number of known adapters in the current config.</td></tr>
-<tr><td>mixer_config_attributes_total</td><td>LastValue</td><td>The number of known attributes in the current config.</td></tr>
-<tr><td>mixer_config_handler_configs_total</td><td>LastValue</td><td>The number of known handlers in the current config.</td></tr>
-<tr><td>mixer_config_instance_config_errors_total</td><td>LastValue</td><td>The number of errors encountered during processing of the instance configuration.</td></tr>
-<tr><td>mixer_config_instance_configs_total</td><td>LastValue</td><td>The number of known instances in the current config.</td></tr>
-<tr><td>mixer_config_rule_config_errors_total</td><td>LastValue</td><td>The number of errors encountered during processing of the rule configuration.</td></tr>
-<tr><td>mixer_config_rule_configs_total</td><td>LastValue</td><td>The number of known rules in the current config.</td></tr>
-</tbody>
-</table>
-`
-
 	// AttributesTotal is a measure of the number of known attributes.
 	AttributesTotal = stats.Int64(
 		"mixer/config/attributes_total",
@@ -93,6 +76,16 @@ var (
 		"mixer/config/adapter_info_configs_total",
 		"The number of known adapters in the current config.",
 		stats.UnitDimensionless)
+
+	want = []metrics.Exported{
+		{"mixer_config_adapter_info_configs_total", "LastValue", "The number of known adapters in the current config."},
+		{"mixer_config_attributes_total", "LastValue", "The number of known attributes in the current config."},
+		{"mixer_config_handler_configs_total", "LastValue", "The number of known handlers in the current config."},
+		{"mixer_config_instance_config_errors_total", "LastValue", "The number of errors encountered during processing of the instance configuration."},
+		{"mixer_config_instance_configs_total", "LastValue", "The number of known instances in the current config."},
+		{"mixer_config_rule_config_errors_total", "LastValue", "The number of errors encountered during processing of the rule configuration."},
+		{"mixer_config_rule_configs_total", "LastValue", "The number of known rules in the current config."},
+	}
 )
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {

--- a/collateral/metrics/opencensus_test.go
+++ b/collateral/metrics/opencensus_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"istio.io/pkg/collateral/metrics"
+)
+
+func TestGenerateHTML(t *testing.T) {
+	registerViews()
+	e := metrics.NewOpenCensusHTMLGenerator()
+
+	if got := e.GenerateHTML(); got != expected {
+		t.Errorf("GenerateHTML() = %v, want %v", got, expected)
+	}
+}
+
+// stolen shamelessly from mixer pkgs in istio/istio for testing purposes
+var (
+	expected = `<h2 id=\"metrics\">Exported Metrics</h2>
+<table class=\"metrics\">
+<thead>
+<tr><th>Name</th><th>Type</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td>mixer_config_adapter_info_configs_total</td><td>LastValue</td><td>The number of known adapters in the current config.</td></tr>
+<tr><td>mixer_config_attributes_total</td><td>LastValue</td><td>The number of known attributes in the current config.</td></tr>
+<tr><td>mixer_config_handler_configs_total</td><td>LastValue</td><td>The number of known handlers in the current config.</td></tr>
+<tr><td>mixer_config_instance_config_errors_total</td><td>LastValue</td><td>The number of errors encountered during processing of the instance configuration.</td></tr>
+<tr><td>mixer_config_instance_configs_total</td><td>LastValue</td><td>The number of known instances in the current config.</td></tr>
+<tr><td>mixer_config_rule_config_errors_total</td><td>LastValue</td><td>The number of errors encountered during processing of the rule configuration.</td></tr>
+<tr><td>mixer_config_rule_configs_total</td><td>LastValue</td><td>The number of known rules in the current config.</td></tr>
+</tbody>
+</table>
+`
+
+	// AttributesTotal is a measure of the number of known attributes.
+	AttributesTotal = stats.Int64(
+		"mixer/config/attributes_total",
+		"The number of known attributes in the current config.",
+		stats.UnitDimensionless)
+
+	// HandlersTotal is a measure of the number of known handlers.
+	HandlersTotal = stats.Int64(
+		"mixer/config/handler_configs_total",
+		"The number of known handlers in the current config.",
+		stats.UnitDimensionless)
+
+	// InstancesTotal is a measure of the number of known instances.
+	InstancesTotal = stats.Int64(
+		"mixer/config/instance_configs_total",
+		"The number of known instances in the current config.",
+		stats.UnitDimensionless)
+
+	// InstanceErrs is a measure of the number of errors for processing instance config.
+	InstanceErrs = stats.Int64(
+		"mixer/config/instance_config_errors_total",
+		"The number of errors encountered during processing of the instance configuration.",
+		stats.UnitDimensionless)
+
+	// RulesTotal is a measure of the number of known rules.
+	RulesTotal = stats.Int64(
+		"mixer/config/rule_configs_total",
+		"The number of known rules in the current config.",
+		stats.UnitDimensionless)
+
+	// RuleErrs is a measure of the number of errors for processing rules config.
+	RuleErrs = stats.Int64(
+		"mixer/config/rule_config_errors_total",
+		"The number of errors encountered during processing of the rule configuration.",
+		stats.UnitDimensionless)
+
+	// AdapterInfosTotal is a measure of the number of known adapters.
+	AdapterInfosTotal = stats.Int64(
+		"mixer/config/adapter_info_configs_total",
+		"The number of known adapters in the current config.",
+		stats.UnitDimensionless)
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+func registerViews() {
+	views := []*view.View{
+		// config views
+		newView(AttributesTotal, []tag.Key{}, view.LastValue()),
+		newView(HandlersTotal, []tag.Key{}, view.LastValue()),
+		newView(InstancesTotal, []tag.Key{}, view.LastValue()),
+		newView(InstanceErrs, []tag.Key{}, view.LastValue()),
+		newView(RulesTotal, []tag.Key{}, view.LastValue()),
+		newView(RuleErrs, []tag.Key{}, view.LastValue()),
+		newView(AdapterInfosTotal, []tag.Key{}, view.LastValue()),
+	}
+
+	view.Register(views...)
+}

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,7 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.20.1 h1:pMEjRZ1M4ebWGikflH7nQpV6+Zr88KBMA2XJD3sbijw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
@@ -198,3 +199,4 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6 h1:lnDXeR6NYxT+Rfa5jKE1CpMfStnJ36/bYOSziS8dubU=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
+istio.io/istio v0.0.0-20190521195402-defec76b0b81 h1:oa4vLWL8ww5lc9VS+hBylhodJOTLbezMzVB//cn5WWM=


### PR DESCRIPTION
This PR adds the ability to export metrics documentation in HTML to the `collateral` package. Currently, only an OpenCensus-based export is provided. Output is an HTML snippet file (`metrics.html`) that consists of a `<table>` that includes name, type, and description. 

Looking for feedback on command name, file location, HTML structure.

Example screenshot of a rendered table for `mixs`:

![image](https://user-images.githubusercontent.com/21148125/58197190-98a32e80-7c80-11e9-9b93-99321dbf7e09.png)
