### PR TITLE
Fix bad HTML output.

### DIFF
--- a/collateral/control.go
+++ b/collateral/control.go
@@ -736,8 +736,8 @@ func (g *generator) genAnnotations(root *cobra.Command) {
 }
 
 func (g *generator) genMetrics() {
-	g.emit(`<h2 id=\"metrics\">Exported Metrics</h2>
-<table class=\"metrics\">
+	g.emit(`<h2 id="metrics">Exported metrics</h2>
+<table class="metrics">
 <thead>
 <tr><th>Metric Name</th><th>Type</th><th>Description</th></tr>
 </thead>


### PR DESCRIPTION
Extra backslashes are resulting in bad HTML.

Also, for Istio docs we only capitalize the first letter in headers, not every word.
