### PR TITLE
feat(monitoring pkg): add new common monitoring package

### DIFF
--- a/collateral/metrics/opencensus_test.go
+++ b/collateral/metrics/opencensus_test.go
@@ -18,64 +18,59 @@ import (
 	"reflect"
 	"testing"
 
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
-
 	"istio.io/pkg/collateral/metrics"
+	"istio.io/pkg/monitoring"
 )
 
 func TestExportedMetrics(t *testing.T) {
-	registerViews()
 	r := metrics.NewOpenCensusRegistry()
 	if got := r.ExportedMetrics(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ExportedMetrics() = %v, want %v", got, want)
 	}
 }
 
-// stolen shamelessly from mixer pkgs in istio/istio for testing purposes
 var (
 	// AttributesTotal is a measure of the number of known attributes.
-	AttributesTotal = stats.Int64(
+	AttributesTotal = monitoring.NewGauge(
 		"mixer/config/attributes_total",
 		"The number of known attributes in the current config.",
-		stats.UnitDimensionless)
+	)
 
 	// HandlersTotal is a measure of the number of known handlers.
-	HandlersTotal = stats.Int64(
+	HandlersTotal = monitoring.NewGauge(
 		"mixer/config/handler_configs_total",
 		"The number of known handlers in the current config.",
-		stats.UnitDimensionless)
+	)
 
 	// InstancesTotal is a measure of the number of known instances.
-	InstancesTotal = stats.Int64(
+	InstancesTotal = monitoring.NewGauge(
 		"mixer/config/instance_configs_total",
 		"The number of known instances in the current config.",
-		stats.UnitDimensionless)
+	)
 
 	// InstanceErrs is a measure of the number of errors for processing instance config.
-	InstanceErrs = stats.Int64(
+	InstanceErrs = monitoring.NewGauge(
 		"mixer/config/instance_config_errors_total",
 		"The number of errors encountered during processing of the instance configuration.",
-		stats.UnitDimensionless)
+	)
 
 	// RulesTotal is a measure of the number of known rules.
-	RulesTotal = stats.Int64(
+	RulesTotal = monitoring.NewGauge(
 		"mixer/config/rule_configs_total",
 		"The number of known rules in the current config.",
-		stats.UnitDimensionless)
+	)
 
 	// RuleErrs is a measure of the number of errors for processing rules config.
-	RuleErrs = stats.Int64(
+	RuleErrs = monitoring.NewGauge(
 		"mixer/config/rule_config_errors_total",
 		"The number of errors encountered during processing of the rule configuration.",
-		stats.UnitDimensionless)
+	)
 
 	// AdapterInfosTotal is a measure of the number of known adapters.
-	AdapterInfosTotal = stats.Int64(
+	AdapterInfosTotal = monitoring.NewGauge(
 		"mixer/config/adapter_info_configs_total",
 		"The number of known adapters in the current config.",
-		stats.UnitDimensionless)
+	)
 
 	want = []metrics.Exported{
 		{"mixer_config_adapter_info_configs_total", "LastValue", "The number of known adapters in the current config."},
@@ -88,27 +83,15 @@ var (
 	}
 )
 
-func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
-	return &view.View{
-		Name:        measure.Name(),
-		Description: measure.Description(),
-		Measure:     measure,
-		TagKeys:     keys,
-		Aggregation: aggregation,
-	}
-}
+func init() {
+	monitoring.MustRegister(
+		AttributesTotal,
+		HandlersTotal,
+		InstancesTotal,
+		InstanceErrs,
+		RulesTotal,
+		RuleErrs,
+		AdapterInfosTotal,
+	)
 
-func registerViews() {
-	views := []*view.View{
-		// config views
-		newView(AttributesTotal, []tag.Key{}, view.LastValue()),
-		newView(HandlersTotal, []tag.Key{}, view.LastValue()),
-		newView(InstancesTotal, []tag.Key{}, view.LastValue()),
-		newView(InstanceErrs, []tag.Key{}, view.LastValue()),
-		newView(RulesTotal, []tag.Key{}, view.LastValue()),
-		newView(RuleErrs, []tag.Key{}, view.LastValue()),
-		newView(AdapterInfosTotal, []tag.Key{}, view.LastValue()),
-	}
-
-	view.Register(views...)
 }

--- a/monitoring/doc.go
+++ b/monitoring/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package monitoring provides a common instrumentation library for Istio components.
+// Use of this library enables collateral generation for collected metrics, as well as
+// a consistent developer experience across Istio codebases.
+package monitoring

--- a/monitoring/example_distribution_test.go
+++ b/monitoring/example_distribution_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package monitoring_test
+
+import "istio.io/pkg/monitoring"
+
+var (
+	method = monitoring.MustCreateLabel("method")
+
+	received_bytes = monitoring.NewDistribution(
+		"received_bytes_total",
+		"Distribution of received bytes by method",
+		[]float64{10, 100, 1000, 10000},
+		monitoring.WithLabels(method),
+		monitoring.WithUnit(monitoring.Bytes),
+	)
+)
+
+func init() {
+	monitoring.MustRegister(received_bytes)
+}
+
+func ExampleNewDistribution() {
+	received_bytes.With(method.Value("/projects/1")).Record(458)
+}

--- a/monitoring/example_distribution_test.go
+++ b/monitoring/example_distribution_test.go
@@ -18,7 +18,7 @@ import "istio.io/pkg/monitoring"
 var (
 	method = monitoring.MustCreateLabel("method")
 
-	received_bytes = monitoring.NewDistribution(
+	receivedBytes = monitoring.NewDistribution(
 		"received_bytes_total",
 		"Distribution of received bytes by method",
 		[]float64{10, 100, 1000, 10000},
@@ -28,9 +28,9 @@ var (
 )
 
 func init() {
-	monitoring.MustRegister(received_bytes)
+	monitoring.MustRegister(receivedBytes)
 }
 
 func ExampleNewDistribution() {
-	received_bytes.With(method.Value("/projects/1")).Record(458)
+	receivedBytes.With(method.Value("/projects/1")).Record(458)
 }

--- a/monitoring/example_gauge_test.go
+++ b/monitoring/example_gauge_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring_test
+
+import "istio.io/pkg/monitoring"
+
+var (
+	pushLatency = monitoring.NewGauge(
+		"push_latency_seconds",
+		"Duration, measured in seconds, of the last push",
+		monitoring.WithUnit(monitoring.Seconds),
+	)
+)
+
+func init() {
+	monitoring.MustRegister(pushLatency)
+}
+
+func ExampleNewGauge() {
+	// only the last recorded value (99.2) will be exported for this gauge
+	pushLatency.Record(77.3)
+	pushLatency.Record(22.8)
+	pushLatency.Record(99.2)
+}

--- a/monitoring/example_sum_test.go
+++ b/monitoring/example_sum_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring_test
+
+import "istio.io/pkg/monitoring"
+
+var (
+	protocol = monitoring.MustCreateLabel("protocol")
+
+	requests = monitoring.NewSum(
+		"requests_total",
+		"Number of requests handled, by protocol",
+		monitoring.WithLabels(protocol),
+	)
+)
+
+func init() {
+	monitoring.MustRegister(requests)
+}
+
+func ExampleNewSum() {
+	// increment on every http request
+	requests.With(protocol.Value("http")).Increment()
+
+	// count gRPC requests double
+	requests.With(protocol.Value("grpc")).Record(2)
+}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -1,0 +1,183 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+type (
+	// A Metric collects numerical observations.
+	Metric interface {
+		// Increment records a value of 1 for the current measure. For Sums,
+		// this is equivalent to adding 1 to the current value. For Gauges,
+		// this is equivalent to setting the value to 1. For Distributions,
+		// this is equivalent to making an observation of value 1.
+		Increment()
+
+		// Name returns the name value of a Metric.
+		Name() string
+
+		// Record makes an observation of the provided value for the given measure.
+		Record(value float64)
+
+		// With creates a new Metric, with the LabelValues provided. This allows creating
+		// a set of pre-dimensioned data for recording purposes. This is primarily used
+		// for documentation and convenience. Metrics created with this method do not need
+		// to be registered (they share the registration of their parent Metric).
+		With(labelValues ...LabelValue) Metric
+
+		// Register configures the Metric for export. It MUST be called before collection
+		// of values for the Metric. An error will be returned if registration fails.
+		Register() error
+	}
+
+	// Options encode changes to the options passed to a Metric at creation time.
+	Options func(*options)
+
+	// A Label provides a named dimension for a Metric.
+	Label tag.Key
+
+	// A LabelValue represents a Label with a specific value. It is used to record
+	// values for a Metric.
+	LabelValue tag.Mutator
+
+	options struct {
+		unit   Unit
+		labels []Label
+	}
+)
+
+// WithLabels provides configuration options for a new Metric, providing the expected
+// dimensions for data collection for that Metric.
+func WithLabels(labels ...Label) Options {
+	return func(opts *options) {
+		opts.labels = labels
+	}
+}
+
+// WithUnit provides configuration options for a new Metric, providing unit of measure
+// information for a new Metric.
+func WithUnit(unit Unit) Options {
+	return func(opts *options) {
+		opts.unit = unit
+	}
+}
+
+// Value creates a new LabelValue for the Label.
+func (l Label) Value(value string) LabelValue {
+	return tag.Upsert(tag.Key(l), value)
+}
+
+// MustCreateLabel will attempt to create a new Label. If
+// creation fails, then this method will panic.
+func MustCreateLabel(key string) Label {
+	k, err := tag.NewKey(key)
+	if err != nil {
+		panic(fmt.Errorf("could not create label %q: %v", key, err))
+	}
+	return Label(k)
+}
+
+// MustRegister is a helper function that will ensure that the provided Metrics are
+// registered. If a metric fails to register, this method will panic.
+func MustRegister(metrics ...Metric) {
+	for _, m := range metrics {
+		if err := m.Register(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// NewSum creates a new Metric with an aggregation type of Sum (the values will be cumulative).
+// That means that data collected by the new Metric will be summed before export.
+func NewSum(name, description string, opts ...Options) Metric {
+	return newMetric(name, description, view.Sum(), opts...)
+}
+
+// NewGauge creates a new Metric with an aggregation type of LastValue. That means that data collected
+// by the new Metric will export only the last recorded value.
+func NewGauge(name, description string, opts ...Options) Metric {
+	return newMetric(name, description, view.LastValue(), opts...)
+}
+
+// NewDistribution creates a new Metric with an aggregration type of Distribution. This means that the
+// data collected by the Metric will be collected and exported as a histogram, with the specified bounds.
+func NewDistribution(name, description string, bounds []float64, opts ...Options) Metric {
+	return newMetric(name, description, view.Distribution(bounds...), opts...)
+}
+
+func newMetric(name, description string, aggregation *view.Aggregation, opts ...Options) Metric {
+	return newFloat64Metric(name, description, aggregation, opts...)
+}
+
+type float64Metric struct {
+	*stats.Float64Measure
+
+	tags []tag.Mutator
+	view *view.View
+}
+
+func createOptions(opts ...Options) *options {
+	o := &options{unit: None, labels: make([]Label, 0)}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func newFloat64Metric(name, description string, aggregation *view.Aggregation, opts ...Options) *float64Metric {
+	o := createOptions(opts...)
+	measure := stats.Float64(name, description, string(o.unit))
+	tagKeys := make([]tag.Key, len(o.labels))
+	for _, l := range o.labels {
+		tagKeys = append(tagKeys, tag.Key(l))
+	}
+	return &float64Metric{
+		measure,
+		make([]tag.Mutator, 0),
+		&view.View{Measure: measure, TagKeys: tagKeys, Aggregation: aggregation},
+	}
+}
+
+func (f *float64Metric) Increment() {
+	f.Record(1)
+}
+
+func (f *float64Metric) Name() string {
+	return f.Float64Measure.Name()
+}
+
+func (f *float64Metric) Record(value float64) {
+	stats.RecordWithTags(context.Background(), f.tags, f.M(value)) //nolint:errcheck
+}
+
+func (f *float64Metric) With(labelValues ...LabelValue) Metric {
+	t := make([]tag.Mutator, len(f.tags))
+	copy(t, f.tags)
+	for _, tagValue := range labelValues {
+		t = append(t, tag.Mutator(tagValue))
+	}
+	return &float64Metric{f.Float64Measure, t, f.view}
+}
+
+func (f *float64Metric) Register() error {
+	return view.Register(f.view)
+}

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -1,0 +1,204 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"istio.io/pkg/monitoring"
+)
+
+var (
+	name = monitoring.MustCreateLabel("name")
+	kind = monitoring.MustCreateLabel("kind")
+
+	testSum = monitoring.NewSum(
+		"events_total",
+		"Number of events observed, by name and kind",
+		monitoring.WithLabels(name, kind),
+	)
+
+	goofySum = testSum.With(kind.Value("goofy"))
+
+	testDistribution = monitoring.NewDistribution(
+		"test_buckets",
+		"Testing distribution functionality",
+		[]float64{0, 2.5, 7, 8, 10, 154.3, 99},
+		monitoring.WithLabels(name),
+		monitoring.WithUnit(monitoring.Seconds),
+	)
+
+	testGauge = monitoring.NewGauge(
+		"test_gauge",
+		"Testing gauge functionality",
+	)
+)
+
+func init() {
+	monitoring.MustRegister(testSum, testDistribution, testGauge)
+}
+
+func TestSum(t *testing.T) {
+	exp := &testExporter{rows: make(map[string][]*view.Row)}
+	view.RegisterExporter(exp)
+	view.SetReportingPeriod(1 * time.Millisecond)
+
+	testSum.With(name.Value("foo"), kind.Value("bar")).Increment()
+	goofySum.With(name.Value("baz")).Record(45)
+
+	time.Sleep(2 * time.Millisecond)
+
+	if len(exp.rows[testSum.Name()]) < 2 {
+		// we should have two values goofySum (which is a dimensioned testSum) and
+		// testSum.
+		t.Error("no values recorded for sum, want 2.")
+	}
+
+	for _, r := range exp.rows[testSum.Name()] {
+		if findTagWithValue("kind", "goofy", r.Tags) {
+			if sd, ok := r.Data.(*view.SumData); ok {
+				if got, want := sd.Value, 45.0; got != want {
+					t.Errorf("bad value for %q: %f, want %f", goofySum.Name(), got, want)
+				}
+			}
+		} else if findTagWithValue("kind", "bar", r.Tags) {
+			if sd, ok := r.Data.(*view.SumData); ok {
+				if got, want := sd.Value, 1.0; got != want {
+					t.Errorf("bad value for %q: %f, want %f", testSum.Name(), got, want)
+				}
+			}
+		} else {
+			t.Errorf("unknown row in results: %v", r)
+		}
+	}
+}
+
+func TestGauge(t *testing.T) {
+	exp := &testExporter{rows: make(map[string][]*view.Row)}
+	view.RegisterExporter(exp)
+	view.SetReportingPeriod(1 * time.Millisecond)
+
+	testGauge.Record(42)
+	testGauge.Record(77)
+
+	time.Sleep(2 * time.Millisecond)
+
+	// only last value should be kept
+	if len(exp.rows[testGauge.Name()]) < 1 {
+		t.Error("no values recorded for gauge, want 1.")
+	}
+
+	for _, r := range exp.rows[testGauge.Name()] {
+		if lvd, ok := r.Data.(*view.LastValueData); ok {
+			if got, want := lvd.Value, 77.0; got != want {
+				t.Errorf("bad value for %q: %f, want %f", testGauge.Name(), got, want)
+			}
+		}
+	}
+}
+
+func TestDistribution(t *testing.T) {
+	exp := &testExporter{rows: make(map[string][]*view.Row)}
+	view.RegisterExporter(exp)
+	view.SetReportingPeriod(1 * time.Millisecond)
+
+	funDistribution := testDistribution.With(name.Value("fun"))
+	funDistribution.Record(7.7773)
+	testDistribution.With(name.Value("foo")).Record(7.4)
+	testDistribution.With(name.Value("foo")).Record(6.8)
+	testDistribution.With(name.Value("foo")).Record(10.2)
+
+	time.Sleep(2 * time.Millisecond)
+
+	if len(exp.rows[testDistribution.Name()]) < 2 {
+		t.Error("no values recorded for distribution, want 2.")
+	}
+
+	for _, r := range exp.rows[testDistribution.Name()] {
+		if findTagWithValue("name", "fun", r.Tags) {
+			if dd, ok := r.Data.(*view.DistributionData); ok {
+				if got, want := dd.Count, int64(1); got != want {
+					t.Errorf("bad count for %q: %d, want %d", testDistribution.Name(), got, want)
+				}
+			}
+		} else if findTagWithValue("name", "foo", r.Tags) {
+			if dd, ok := r.Data.(*view.DistributionData); ok {
+				if got, want := dd.Count, int64(3); got != want {
+					t.Errorf("bad count for %q: %d, want %d", testDistribution.Name(), got, want)
+				}
+			}
+		} else {
+			t.Error("expected distributions not found.")
+		}
+	}
+}
+
+func TestMustCreateLabel(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			if !strings.Contains(r.(error).Error(), "label") {
+				t.Errorf("no panic for invalid label, recovered: %q", r.(error).Error())
+			}
+		} else {
+			t.Error("no panic for failed label creation.")
+		}
+	}()
+
+	// labels must be ascii
+	monitoring.MustCreateLabel("£®")
+}
+
+func TestMustRegister(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("no panic for failed registration.")
+		}
+	}()
+
+	monitoring.MustRegister(&registerFail{})
+}
+
+type registerFail struct {
+	monitoring.Metric
+}
+
+func (r registerFail) Register() error {
+	return errors.New("fail")
+}
+
+type testExporter struct {
+	rows map[string][]*view.Row
+}
+
+func (t *testExporter) ExportView(d *view.Data) {
+	for _, r := range d.Rows {
+		t.rows[d.View.Name] = append(t.rows[d.View.Name], r)
+	}
+}
+
+func findTagWithValue(key, value string, tags []tag.Tag) bool {
+	for _, t := range tags {
+		if t.Key.Name() == key && t.Value == value {
+			return true
+		}
+	}
+	return false
+}

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -189,9 +189,7 @@ type testExporter struct {
 }
 
 func (t *testExporter) ExportView(d *view.Data) {
-	for _, r := range d.Rows {
-		t.rows[d.View.Name] = append(t.rows[d.View.Name], r)
-	}
+	t.rows[d.View.Name] = append(t.rows[d.View.Name], d.Rows...)
 }
 
 func findTagWithValue(key, value string, tags []tag.Tag) bool {

--- a/monitoring/units.go
+++ b/monitoring/units.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+// Unit encodes the standard name for describing the quantity
+// measured by a Metric (if applicable).
+type Unit string
+
+// Predefined units for use with the monitoring package.
+const (
+	None         Unit = "1"
+	Bytes        Unit = "By"
+	Seconds      Unit = "s"
+	Milliseconds Unit = "ms"
+)


### PR DESCRIPTION
This PR adds a new common package for monitoring Istio components. It wraps the OpenCensus libraries with a developer-friendly API, allowing easy collateral generation and a consistent interface across components. There have been several PRs recently requesting such a monitoring package for broad `istio.io/istio` usage. This PR serves as a small refinement on the existing `istio.io/istio/pilot/pkg/monitoring` package, which it is intended to replace.

Examples have been provided to demonstrate the API in use.