### PR TITLE
[monitoring] Add decrement method 

### DIFF
--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -32,6 +32,12 @@ type (
 		// this is equivalent to making an observation of value 1.
 		Increment()
 
+		// Decrement records a value of -1 for the current measure. For Sums,
+		// this is equivalent to subtracting -1 to the current value. For Gauges,
+		// this is equivalent to setting the value to -1. For Distributions,
+		// this is equivalent to making an observation of value -1.
+		Decrement()
+
 		// Name returns the name value of a Metric.
 		Name() string
 
@@ -159,6 +165,10 @@ func newFloat64Metric(name, description string, aggregation *view.Aggregation, o
 
 func (f *float64Metric) Increment() {
 	f.Record(1)
+}
+
+func (f *float64Metric) Decrement() {
+	f.Record(-1)
 }
 
 func (f *float64Metric) Name() string {

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -64,6 +64,7 @@ func TestSum(t *testing.T) {
 
 	testSum.With(name.Value("foo"), kind.Value("bar")).Increment()
 	goofySum.With(name.Value("baz")).Record(45)
+	goofySum.With(name.Value("baz")).Decrement()
 
 	time.Sleep(2 * time.Millisecond)
 
@@ -76,7 +77,7 @@ func TestSum(t *testing.T) {
 	for _, r := range exp.rows[testSum.Name()] {
 		if findTagWithValue("kind", "goofy", r.Tags) {
 			if sd, ok := r.Data.(*view.SumData); ok {
-				if got, want := sd.Value, 45.0; got != want {
+				if got, want := sd.Value, 44.0; got != want {
 					t.Errorf("bad value for %q: %f, want %f", goofySum.Name(), got, want)
 				}
 			}


### PR DESCRIPTION
Add this method rather than doing `.Record(-1)`. This method should only be used for Sum type. 