### PR TITLE
Add Viperize for brevity

### DIFF
--- a/viperconfig/testsubconfig.yaml
+++ b/viperconfig/testsubconfig.yaml
@@ -1,0 +1,2 @@
+foo: "expected"
+bar: "alsoexpected"

--- a/viperconfig/viperconfig.go
+++ b/viperconfig/viperconfig.go
@@ -71,10 +71,7 @@ func subCommandPreRun(cmd *cobra.Command, viper *viper.Viper) {
 		if original != nil {
 			original(cmd, args)
 		}
-		flags := cmd.Flags()
-		pflags := cmd.PersistentFlags()
-		fmt.Println(pflags)
-		viper.BindPFlags(flags)
+		_ = viper.BindPFlags(cmd.Flags())
 		ProcessViperConfig(cmd, viper)
 	}
 

--- a/viperconfig/viperconfig_test.go
+++ b/viperconfig/viperconfig_test.go
@@ -30,10 +30,13 @@ func TestViperConfig(t *testing.T) {
 		ProcessViperConfig(c, v)
 		assert.Equal(t, foo, "expected")
 		hasRun = true
-	}}
+	},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			v.BindPFlags(cmd.Flags())
+		}}
 	AddConfigFlag(&c, v)
 	c.PersistentFlags().StringVar(&foo, "foo", "notempty", "foo is a fake flag")
-	v.BindPFlags(c.PersistentFlags())
+
 	c.SetArgs([]string{"--config", "testconfig.yaml"})
 	c.Execute()
 	if !hasRun {

--- a/viperconfig/viperconfig_test.go
+++ b/viperconfig/viperconfig_test.go
@@ -40,3 +40,45 @@ func TestViperConfig(t *testing.T) {
 		assert.True(t, hasRun, "command never ran")
 	}
 }
+
+func TestViperize(t *testing.T) {
+	var foo string
+	var bar string
+	hasRunRoot := false
+	hasRunPre := false
+	hasRunSub := false
+	c := cobra.Command{Run: func(c *cobra.Command, args []string) {
+		assert.Equal(t, foo, "expected")
+		hasRunRoot = true
+	}, PreRun: func(c *cobra.Command, args []string) {
+		hasRunPre = true
+	}}
+	c.PersistentFlags().StringVar(&foo, "foo", "notempty", "foo is a fake flag")
+	sub := cobra.Command{Use: "sub", Run: func(c *cobra.Command, args []string) {
+		// this is not getting set, probably because it's not in sub's persistent flag set...
+		assert.Equal(t, foo, "expected")
+		assert.Equal(t, bar, "alsoexpected")
+		hasRunSub = true
+	}}
+	sub.PersistentFlags().StringVar(&bar, "bar", "notepmty", "bar is also a fake flag")
+	c.AddCommand(&sub)
+	ViperizeRootCmdDefault(&c)
+	// run root and check
+	c.SetArgs([]string{"--config", "testconfig.yaml"})
+	c.Execute()
+	assert.True(t, hasRunRoot, "root command never ran")
+	assert.True(t, hasRunPre, "root command never preran")
+	assert.False(t, hasRunSub, "subcommand ran unintentionally")
+	// reset the test
+	foo = ""
+	bar = ""
+	hasRunRoot = false
+	hasRunSub = false
+	hasRunPre = false
+	// run sub and check
+	c.SetArgs([]string{"sub", "--config", "testsubconfig.yaml"})
+	c.Execute()
+	assert.True(t, hasRunSub, "subcommand never ran")
+	assert.False(t, hasRunRoot, "root command ran unintentionally")
+	assert.False(t, hasRunPre, "root command preran unintentionally")
+}


### PR DESCRIPTION
Original functionality in this module had to be called three times (including a separate viper call) per command in order to provide consistent functionality.  This function need only be called once per root command, reducing the amount of code that has to be splattered across the codebase by about 9x.  Once Istio has been updated to use only viperize, we might consider making the other functions private.