### PR TITLE
Revert "Retire now superfluous pkg/annotations. (#42)"

### DIFF
--- a/annotations/annotation.go
+++ b/annotations/annotation.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package annotations makes it possible to track use of resource annotations within a procress
+// in order to generate documentation for these uses.
+package annotations
+
+import (
+	"sort"
+	"sync"
+
+	"istio.io/pkg/log"
+)
+
+// Annotation describes a single resource annotation
+type Annotation struct {
+	// The name of the annotation.
+	Name string
+
+	// Description of the annotation.
+	Description string
+
+	// Hide the existence of this annotation when outputting usage information.
+	Hidden bool
+
+	// Mark this annotation as deprecated when generating usage information.
+	Deprecated bool
+}
+
+var allAnnotations = make(map[string]Annotation)
+var mutex sync.Mutex
+
+// Returns a description of this process' annotations, sorted by name.
+func Descriptions() []Annotation {
+	mutex.Lock()
+	sorted := make([]Annotation, 0, len(allAnnotations))
+	for _, v := range allAnnotations {
+		sorted = append(sorted, v)
+	}
+	mutex.Unlock()
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	return sorted
+}
+
+// Register registers a new annotation.
+func Register(name string, description string) Annotation {
+	a := Annotation{Name: name, Description: description}
+	RegisterFull(a)
+
+	// get what's actually been registered
+	mutex.Lock()
+	result := allAnnotations[name]
+	mutex.Unlock()
+
+	return result
+}
+
+// RegisterFull registers a new annotation.
+func RegisterFull(a Annotation) {
+	mutex.Lock()
+
+	if old, ok := allAnnotations[a.Name]; ok {
+		if a.Description != "" {
+			allAnnotations[a.Name] = a // last one with a description wins if the same annotation name is registered multiple times
+		}
+
+		if old.Description != a.Description || old.Deprecated != a.Deprecated || old.Hidden != a.Hidden {
+			log.Warnf("The annotation %s was registered multiple times using different metadata: %v, %v", a.Name, old, a)
+		}
+	} else {
+		allAnnotations[a.Name] = a
+	}
+
+	mutex.Unlock()
+}

--- a/annotations/annotation_test.go
+++ b/annotations/annotation_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package env makes it possible to track use of environment variables within procress
+// in order to generate documentation for these uses.
+package annotations
+
+import (
+	"os"
+	"testing"
+)
+
+const testAnnotation = "TESTXYZ"
+
+func reset() {
+	_ = os.Unsetenv(testAnnotation)
+	mutex.Lock()
+	allAnnotations = make(map[string]Annotation)
+	mutex.Unlock()
+}
+
+func TestBasic(t *testing.T) {
+	reset()
+
+	_ = Register(testAnnotation+"2", "Two")
+	_ = Register(testAnnotation+"0", "Zero")
+	_ = Register(testAnnotation+"1", "One")
+
+	a := Descriptions()
+	if a[0].Name != "TESTXYZ0" {
+		t.Errorf("Expecting TESTXYZ0, got %s", a[0].Name)
+	}
+	if a[0].Description != "Zero" {
+		t.Errorf("Expected 'Zero', got '%s'", a[0].Description)
+	}
+
+	if a[1].Name != "TESTXYZ1" {
+		t.Errorf("Expecting TESTXYZ1, got %s", a[0].Name)
+	}
+	if a[1].Description != "One" {
+		t.Errorf("Expected 'One', got '%s'", a[0].Description)
+	}
+
+	if a[2].Name != "TESTXYZ2" {
+		t.Errorf("Expecting TESTXYZ2, got %s", a[0].Name)
+	}
+	if a[2].Description != "Two" {
+		t.Errorf("Expected '2', got '%s'", a[0].Description)
+	}
+}
+
+func TestDupes(t *testing.T) {
+	// make sure annotation without a description doesn't overwrite one with
+	reset()
+	_ = Register(testAnnotation, "XYZ")
+	a := Register(testAnnotation, "")
+	if a.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", a.Description)
+	}
+
+	// make sure annotation without a description doesn't overwrite one with
+	reset()
+	_ = Register(testAnnotation, "")
+	a = Register(testAnnotation, "XYZ")
+	if a.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", a.Description)
+	}
+}


### PR DESCRIPTION
This reverts commit e5d6de6b352b0a7ae2bcc51bc9644e92d2d6065a.

Fixes https://github.com/istio/istio/issues/16006