### PR TITLE
Remove Host, User, and Hub from version string

### DIFF
--- a/version/cobra_test.go
+++ b/version/cobra_test.go
@@ -107,15 +107,15 @@ func TestOpts(t *testing.T) {
 }
 
 var meshInfoSingleVersion = MeshInfo{
-	{"Pilot", BuildInfo{"1.2.0", "gitSHA123", "user1", "host1", "go1.10", "hub.docker.com", "Clean", "tag"}},
-	{"Injector", BuildInfo{"1.2.0", "gitSHAabc", "user2", "host2", "go1.10.1", "hub.docker.com", "Modified", "tag"}},
-	{"Citadel", BuildInfo{"1.2.0", "gitSHA321", "user3", "host3", "go1.11.0", "hub.docker.com", "Clean", "tag"}},
+	{"Pilot", BuildInfo{"1.2.0", "gitSHA123", "go1.10", "Clean", "tag"}},
+	{"Injector", BuildInfo{"1.2.0", "gitSHAabc", "go1.10.1", "Modified", "tag"}},
+	{"Citadel", BuildInfo{"1.2.0", "gitSHA321", "go1.11.0", "Clean", "tag"}},
 }
 
 var meshInfoMultiVersion = MeshInfo{
-	{"Pilot", BuildInfo{"1.0.0", "gitSHA123", "user1", "host1", "go1.10", "hub.docker.com", "Clean", "1.0.0"}},
-	{"Injector", BuildInfo{"1.0.1", "gitSHAabc", "user2", "host2", "go1.10.1", "hub.docker.com", "Modified", "1.0.1"}},
-	{"Citadel", BuildInfo{"1.2", "gitSHA321", "user3", "host3", "go1.11.0", "hub.docker.com", "Clean", "1.2"}},
+	{"Pilot", BuildInfo{"1.0.0", "gitSHA123", "go1.10", "Clean", "1.0.0"}},
+	{"Injector", BuildInfo{"1.0.1", "gitSHAabc", "go1.10.1", "Modified", "1.0.1"}},
+	{"Citadel", BuildInfo{"1.2", "gitSHA321", "go1.11.0", "Clean", "1.2"}},
 }
 
 func mockRemoteMesh(meshInfo *MeshInfo) GetRemoteVersionFunc {
@@ -167,8 +167,8 @@ func TestVersion(t *testing.T) {
 		{ // case 0 client-side only, normal output
 			args: strings.Split("version --remote=false --short=false", " "),
 			expectedRegexp: regexp.MustCompile("version.BuildInfo{Version:\"unknown\", GitRevision:\"unknown\", " +
-				"User:\"unknown\", Host:\"unknown\", GolangVersion:\"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\", " +
-				"DockerHub:\"unknown\", BuildStatus:\"unknown\", GitTag:\"unknown\"}"),
+				"GolangVersion:\"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\", " +
+				"BuildStatus:\"unknown\", GitTag:\"unknown\"}"),
 		},
 		{ // case 1 client-side only, short output
 			args:           strings.Split("version -s --remote=false", " "),
@@ -178,12 +178,9 @@ func TestVersion(t *testing.T) {
 			args: strings.Split("version --remote=false -o yaml", " "),
 			expectedRegexp: regexp.MustCompile("clientVersion:\n" +
 				"  golang_version: go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\n" +
-				"  host: unknown\n" +
-				"  hub: unknown\n" +
 				"  revision: unknown\n" +
 				"  status: unknown\n" +
 				"  tag: unknown\n" +
-				"  user: unknown\n" +
 				"  version: unknown\n\n"),
 		},
 		{ // case 3 client-side only, json output
@@ -192,10 +189,7 @@ func TestVersion(t *testing.T) {
 				"  \"clientVersion\": {\n" +
 				"    \"version\": \"unknown\",\n" +
 				"    \"revision\": \"unknown\",\n" +
-				"    \"user\": \"unknown\",\n" +
-				"    \"host\": \"unknown\",\n" +
 				"    \"golang_version\": \"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\",\n" +
-				"    \"hub\": \"unknown\",\n" +
 				"    \"status\": \"unknown\",\n" +
 				"    \"tag\": \"unknown\"\n" +
 				"  }\n" +
@@ -206,8 +200,8 @@ func TestVersion(t *testing.T) {
 			args:       strings.Split("version --remote=true --short=false --output=", " "),
 			remoteMesh: &meshInfoMultiVersion,
 			expectedRegexp: regexp.MustCompile("client version: version.BuildInfo{Version:\"unknown\", GitRevision:\"unknown\", " +
-				"User:\"unknown\", Host:\"unknown\", GolangVersion:\"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\", " +
-				"DockerHub:\"unknown\", BuildStatus:\"unknown\", GitTag:\"unknown\"}\n" +
+				"GolangVersion:\"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\", " +
+				"BuildStatus:\"unknown\", GitTag:\"unknown\"}\n" +
 				printMeshVersion(&meshInfoMultiVersion, rawOutputMock)),
 		},
 		{ // case 5 remote, short output
@@ -220,12 +214,9 @@ func TestVersion(t *testing.T) {
 			remoteMesh: &meshInfoMultiVersion,
 			expectedRegexp: regexp.MustCompile("clientVersion:\n" +
 				"  golang_version: go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\n" +
-				"  host: unknown\n" +
-				"  hub: unknown\n" +
 				"  revision: unknown\n" +
 				"  status: unknown\n" +
 				"  tag: unknown\n" +
-				"  user: unknown\n" +
 				"  version: unknown\n" + printMeshVersion(&meshInfoMultiVersion, yamlOutputMock)),
 		},
 		{ // case 7 remote, json output
@@ -235,10 +226,7 @@ func TestVersion(t *testing.T) {
 				"  \"clientVersion\": {\n" +
 				"    \"version\": \"unknown\",\n" +
 				"    \"revision\": \"unknown\",\n" +
-				"    \"user\": \"unknown\",\n" +
-				"    \"host\": \"unknown\",\n" +
 				"    \"golang_version\": \"go1.([0-9+?(\\.)?]+)(rc[0-9]?)?\",\n" +
-				"    \"hub\": \"unknown\",\n" +
 				"    \"status\": \"unknown\",\n" +
 				"    \"tag\": \"unknown\"\n" +
 				"  },\n" +

--- a/version/version.go
+++ b/version/version.go
@@ -26,9 +26,6 @@ import (
 var (
 	buildVersion     = "unknown"
 	buildGitRevision = "unknown"
-	buildUser        = "unknown"
-	buildHost        = "unknown"
-	buildDockerHub   = "unknown"
 	buildStatus      = "unknown"
 	buildTag         = "unknown"
 )
@@ -37,10 +34,7 @@ var (
 type BuildInfo struct {
 	Version       string `json:"version"`
 	GitRevision   string `json:"revision"`
-	User          string `json:"user"`
-	Host          string `json:"host"`
 	GolangVersion string `json:"golang_version"`
-	DockerHub     string `json:"hub"`
 	BuildStatus   string `json:"status"`
 	GitTag        string `json:"tag"`
 }
@@ -75,10 +69,6 @@ func NewBuildInfoFromOldString(oldOutput string) (BuildInfo, error) {
 				res.Version = value
 			case "GitRevision":
 				res.GitRevision = value
-			case "User":
-				res.User = value
-			case "Hub":
-				res.DockerHub = value
 			case "GolangVersion":
 				res.GolangVersion = value
 			case "BuildStatus":
@@ -86,7 +76,8 @@ func NewBuildInfoFromOldString(oldOutput string) (BuildInfo, error) {
 			case "GitTag":
 				res.GitTag = value
 			default:
-				return BuildInfo{}, fmt.Errorf("invalid BuildInfo input, field '%s' is not valid", fields[0])
+				// Skip unknown fields, as older versions may report other fields
+				continue
 			}
 		}
 	}
@@ -104,13 +95,10 @@ var (
 // This looks like:
 //
 // ```
-// user@host-<docker hub>-<version>-<git revision>-<build status>
+// u<version>-<git revision>-<build status>
 // ```
 func (b BuildInfo) String() string {
-	return fmt.Sprintf("%v@%v-%v-%v-%v-%v",
-		b.User,
-		b.Host,
-		b.DockerHub,
+	return fmt.Sprintf("%v-%v-%v",
 		b.Version,
 		b.GitRevision,
 		b.BuildStatus)
@@ -127,10 +115,7 @@ func init() {
 	Info = BuildInfo{
 		Version:       buildVersion,
 		GitRevision:   buildGitRevision,
-		User:          buildUser,
-		Host:          buildHost,
 		GolangVersion: runtime.Version(),
-		DockerHub:     buildDockerHub,
 		BuildStatus:   buildStatus,
 		GitTag:        buildTag,
 	}

--- a/version/version_linux_test.go
+++ b/version/version_linux_test.go
@@ -32,10 +32,7 @@ func TestRecordComponentBuildTag(t *testing.T) {
 		{"record", BuildInfo{
 			Version:       "VER",
 			GitRevision:   "GITREV",
-			Host:          "HOST",
 			GolangVersion: "GOLANGVER",
-			DockerHub:     "DH",
-			User:          "USER",
 			BuildStatus:   "STATUS",
 			GitTag:        "1.0.5-test"},
 			"1.0.5-test",
@@ -67,10 +64,7 @@ func TestRecordComponentBuildTagError(t *testing.T) {
 	bi := BuildInfo{
 		Version:       "VER",
 		GitRevision:   "GITREV",
-		Host:          "HOST",
 		GolangVersion: "GOLANGVER",
-		DockerHub:     "DH",
-		User:          "USER",
 		BuildStatus:   "STATUS",
 		GitTag:        "TAG",
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -31,7 +31,23 @@ func TestNewBuildInfoFromOldString(t *testing.T) {
 			"Correct input 1",
 			`Version: 1.0.0
 GitRevision: 3a136c90ec5e308f236e0d7ebb5c4c5e405217f4
+GolangVersion: go1.10.1
+BuildStatus: Clean
+GitTag: tag
+`,
+			false,
+			BuildInfo{Version: "1.0.0",
+				GitRevision:   "3a136c90ec5e308f236e0d7ebb5c4c5e405217f4",
+				GolangVersion: "go1.10.1",
+				BuildStatus:   "Clean",
+				GitTag:        "tag"},
+		},
+		{
+			"Legacy input 1",
+			`Version: 1.0.0
+GitRevision: 3a136c90ec5e308f236e0d7ebb5c4c5e405217f4
 User: root@71a9470ea93c
+Host: foo
 Hub: docker.io/istio
 GolangVersion: go1.10.1
 BuildStatus: Clean
@@ -40,8 +56,6 @@ GitTag: tag
 			false,
 			BuildInfo{Version: "1.0.0",
 				GitRevision:   "3a136c90ec5e308f236e0d7ebb5c4c5e405217f4",
-				User:          "root@71a9470ea93c",
-				DockerHub:     "docker.io/istio",
 				GolangVersion: "go1.10.1",
 				BuildStatus:   "Clean",
 				GitTag:        "tag"},
@@ -55,7 +69,7 @@ GitTag: tag
 		{
 			"Invalid input 2",
 			"Xuxa:Xuxo",
-			true,
+			false,
 			BuildInfo{},
 		},
 	}
@@ -78,8 +92,8 @@ GitTag: tag
 }
 
 func TestBuildInfo(t *testing.T) {
-	versionedString := fmt.Sprintf(`version.BuildInfo{Version:"unknown", GitRevision:"unknown", User:"unknown", `+
-		`Host:"unknown", GolangVersion:"%s", DockerHub:"unknown", BuildStatus:"unknown", GitTag:"unknown"}`,
+	versionedString := fmt.Sprintf(`version.BuildInfo{Version:"unknown", GitRevision:"unknown", `+
+		`GolangVersion:"%s", BuildStatus:"unknown", GitTag:"unknown"}`,
 		runtime.Version())
 
 	cases := []struct {
@@ -91,17 +105,14 @@ func TestBuildInfo(t *testing.T) {
 		{"all specified", BuildInfo{
 			Version:       "VER",
 			GitRevision:   "GITREV",
-			Host:          "HOST",
 			GolangVersion: "GOLANGVER",
-			DockerHub:     "DH",
-			User:          "USER",
 			BuildStatus:   "STATUS",
 			GitTag:        "TAG"},
-			"USER@HOST-DH-VER-GITREV-STATUS",
-			`version.BuildInfo{Version:"VER", GitRevision:"GITREV", User:"USER", Host:"HOST", GolangVersion:"GOLANGVER", DockerHub:"DH", ` +
+			"VER-GITREV-STATUS",
+			`version.BuildInfo{Version:"VER", GitRevision:"GITREV", GolangVersion:"GOLANGVER", ` +
 				`BuildStatus:"STATUS", GitTag:"TAG"}`},
 
-		{"init", Info, "unknown@unknown-unknown-unknown-unknown-unknown", versionedString}}
+		{"init", Info, "unknown-unknown-unknown", versionedString}}
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
These fields are not useful, and I don't think are appropriate to
include in our builds.

Host and User are either not useful or not "professional" - the normal
build will be "root" and some random SHA, but in a security fix it may
show up as howardjohn (this has happened in official releases).

Dockerhub doesn't really make any sense. When I run `make istioctl` it
doesn't have anything to do with docker. Even for pilot, which will
eventually be put into a dockerfile, it doesn't make sense. When the
binary is built we should only include metadata about that binary --
where it will eventually be packaged is just a guess that is wrong in
many cases.

Kubernetes was used as inspiration -- they do not have these fields.

For https://github.com/istio/istio/issues/16673