### PR TITLE
Reimplement FileWatcher without races.

### DIFF
--- a/filewatcher/fakefilewatcher.go
+++ b/filewatcher/fakefilewatcher.go
@@ -22,7 +22,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-// NewFileWatcherFunc returns a functions which creates a new file
+// NewFileWatcherFunc returns a function which creates a new file
 // watcher. This may be used to provide test hooks for using the
 // FakeWatcher implementation below.
 type NewFileWatcherFunc func() FileWatcher

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,270 +15,180 @@
 package filewatcher
 
 import (
-	"bufio"
-	"crypto/md5"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
-	multierror "github.com/hashicorp/go-multierror"
 )
 
 // FileWatcher is an interface that watches a set of files,
 // delivering events to related channel.
 type FileWatcher interface {
+
+	// Start watching a path. Calling Add multiple times on the same path panics.
 	Add(path string) error
+
+	// Stop watching a path. Removing a path that's not currently being watched panics.
 	Remove(path string) error
+
 	Close() error
 	Events(path string) chan fsnotify.Event
 	Errors(path string) chan error
 }
 
-type fsNotifyWatcher struct {
+type fileWatcher struct {
 	mu sync.RWMutex
+
 	// The watcher maintain a map of workers,
 	// keyed by watched dir (parent dir of watched files).
-	workers map[string]*worker
+	workers map[string]*workerState
 }
 
-type worker struct {
-	// watcher is a fsnotify watcher that watches the parent
-	// dir of watchedFiles.
-	watcher *fsnotify.Watcher
-	// The worker maintain a map of event channel (included in fileTracker),
-	// keyed by watched file path.
-	// The worker watches parent path of given path,
-	// and filter out events of given path, then redirect
-	// to the result channel.
-	// Note that for symlink files, the content in received events
-	// do not have to be related to the file itself.
-	watchedFiles map[string]*fileTracker
+type workerState struct {
+	worker *worker
+	count  int
 }
 
-type fileTracker struct {
-	events chan fsnotify.Event
-	errors chan error
-	// md5 sum to indicate if a file has been updated.
-	md5Sum string
+// functions that can be replaced in a test setting
+type patchTable struct {
+	newWatcher     func() (*fsnotify.Watcher, error)
+	addWatcherPath func(*fsnotify.Watcher, string) error
+	panic          func(string)
+}
+
+// function table that can be replaced by tests
+var funcs = &patchTable{
+	newWatcher: fsnotify.NewWatcher,
+	addWatcherPath: func(watcher *fsnotify.Watcher, path string) error {
+		return watcher.Add(path)
+	},
+	panic: func(msg string) {
+		panic(msg)
+	},
 }
 
 // NewWatcher return with a FileWatcher instance that implemented with fsnotify.
 func NewWatcher() FileWatcher {
-	w := &fsNotifyWatcher{
-		workers: map[string]*worker{},
+	return &fileWatcher{
+		workers: map[string]*workerState{},
 	}
-
-	return w
 }
 
-// Add is implementation of Add interface of FileWatcher.
-func (w *fsNotifyWatcher) Add(path string) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+// Close releases all resources associated with the watcher
+func (fw *fileWatcher) Close() error {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
 
-	cleanedPath, parentPath := formatPath(path)
-	if worker, workerExist := w.workers[parentPath]; workerExist {
-		if _, pathExist := worker.watchedFiles[cleanedPath]; pathExist {
-			return fmt.Errorf("path %s already added", path)
-		}
-
-		// And the path into worker maps if not exist.
-		md5Sum, err := getMd5Sum(cleanedPath)
-		if err != nil {
-			return fmt.Errorf("failed to get md5 sum for %s: %v", path, err)
-		}
-		worker.watchedFiles[cleanedPath] = &fileTracker{
-			events: make(chan fsnotify.Event, 1),
-			errors: make(chan error, 1),
-			md5Sum: md5Sum,
-		}
-
-		return nil
+	for _, ws := range fw.workers {
+		ws.worker.terminate()
 	}
-
-	// Build a new worker if not exist.
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return err
-	}
-	if err = watcher.Add(parentPath); err != nil {
-		watcher.Close()
-		return err
-	}
-
-	var md5Sum string
-
-	if _, err = os.Stat(cleanedPath); err == nil {
-		md5Sum, err = getMd5Sum(cleanedPath)
-		if err != nil {
-			watcher.Close()
-			return fmt.Errorf("failed to get md5 sum for %s: %v", path, err)
-		}
-	} else if !os.IsNotExist(err) {
-		// if the file doesn't exist, ignore the md5 sum.
-		watcher.Close()
-		return fmt.Errorf("failed to stat file: %s: %v", path, err)
-	}
-
-	wk := &worker{
-		watcher: watcher,
-		watchedFiles: map[string]*fileTracker{
-			cleanedPath: {
-				events: make(chan fsnotify.Event, 1),
-				errors: make(chan error, 1),
-				md5Sum: md5Sum,
-			},
-		},
-	}
-	w.workers[parentPath] = wk
-
-	go func() {
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok { // 'Events' channel is closed
-					return
-				}
-
-				for path, tracker := range wk.watchedFiles {
-					newSum, _ := getMd5Sum(path)
-					if newSum != "" && newSum != tracker.md5Sum {
-						tracker.md5Sum = newSum
-						tracker.events <- event
-						break
-					}
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					// 'Errors' channel is closed. Construct an error for it.
-					// We'll only close worker errors channel in "Remove" for consistency.
-					err = errors.New("channel closed")
-				}
-				for _, tracker := range wk.watchedFiles {
-					tracker.errors <- err
-				}
-				return
-			}
-		}
-	}()
+	fw.workers = nil
 
 	return nil
 }
 
-// Remove is implementation of Remove interface of FileWatcher.
-func (w *fsNotifyWatcher) Remove(path string) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+// Add a path to watch
+func (fw *fileWatcher) Add(path string) error {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
 
-	return w.remove(path)
+	ws, cleanedPath, _, err := fw.getWorker(path)
+	if err != nil {
+		return err
+	}
+
+	ws.worker.addPath(cleanedPath)
+	ws.count++
+
+	return nil
 }
 
-func (w *fsNotifyWatcher) remove(path string) error {
-	cleanedPath, parentPath := formatPath(path)
+// Stop watching a path
+func (fw *fileWatcher) Remove(path string) error {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
 
-	worker, workerExist := w.workers[parentPath]
-	if !workerExist {
-		return fmt.Errorf("path %s already removed", path)
+	ws, cleanedPath, parentPath, err := fw.getWorker(path)
+	if err != nil {
+		return err
 	}
 
-	tracker, pathExist := worker.watchedFiles[cleanedPath]
-	if !pathExist {
-		return fmt.Errorf("path %s already removed", path)
-	}
+	ws.worker.removePath(cleanedPath)
 
-	delete(worker.watchedFiles, cleanedPath)
-	close(tracker.events)
-	close(tracker.errors)
-	if len(worker.watchedFiles) == 0 {
-		// Remove the watch if all of its paths have been removed.
-		delete(w.workers, parentPath)
-		return worker.watcher.Close()
+	ws.count--
+	if ws.count == 0 {
+		ws.worker.terminate()
+		delete(fw.workers, parentPath)
 	}
 
 	return nil
 }
 
-// Close is implementation of Close interface of FileWatcher.
-func (w *fsNotifyWatcher) Close() error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+// Events returns an event notification channel for a path
+func (fw *fileWatcher) Events(path string) chan fsnotify.Event {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
 
-	var errors *multierror.Error
-	for _, worker := range w.workers {
-		for path := range worker.watchedFiles {
-			errors = multierror.Append(errors, w.remove(path))
-		}
-	}
-
-	return errors.ErrorOrNil()
-}
-
-// Events is implementation of Events interface of FileWatcher.
-func (w *fsNotifyWatcher) Events(path string) chan fsnotify.Event {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	cleanedPath, parentPath := formatPath(path)
-	worker, workerExist := w.workers[parentPath]
-	if !workerExist {
-		return nil
-	}
-
-	tracker, pathExist := worker.watchedFiles[cleanedPath]
-	if !pathExist {
-		return nil
-	}
-
-	return tracker.events
-}
-
-// Errors is implementation of Errors interface of FileWatcher.
-func (w *fsNotifyWatcher) Errors(path string) chan error {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	cleanedPath, parentPath := formatPath(path)
-	worker, workerExist := w.workers[parentPath]
-	if !workerExist {
-		return nil
-	}
-
-	tracker, pathExist := worker.watchedFiles[cleanedPath]
-	if !pathExist {
-		return nil
-	}
-
-	return tracker.errors
-}
-
-// getMd5Sum is a helper func to calculate md5 sum.
-func getMd5Sum(file string) (string, error) {
-	f, err := os.Open(file)
+	ws, cleanedPath, err := fw.findWorker(path)
 	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	r := bufio.NewReader(f)
-
-	h := md5.New()
-
-	_, err = io.Copy(h, r)
-	if err != nil {
-		return "", err
+		return nil
 	}
 
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return ws.worker.eventChannel(cleanedPath)
 }
 
-// formatPath return with the path after Clean,
-// as well as its parent path.
-func formatPath(path string) (string, string) {
+// Errors returns an error notification channel for a path
+func (fw *fileWatcher) Errors(path string) chan error {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
+
+	ws, cleanedPath, err := fw.findWorker(path)
+	if err != nil {
+		return nil
+	}
+
+	return ws.worker.errorChannel(cleanedPath)
+}
+
+func (fw *fileWatcher) getWorker(path string) (*workerState, string, string, error) {
+	if fw.workers == nil {
+		return nil, "", "", errors.New("using a closed watcher")
+	}
+
 	cleanedPath := filepath.Clean(path)
 	parentPath, _ := filepath.Split(cleanedPath)
 
-	return cleanedPath, parentPath
+	ws, workerExists := fw.workers[parentPath]
+	if !workerExists {
+		wk, err := newWorker(parentPath)
+		if err != nil {
+			return nil, "", "", err
+		}
+
+		ws = &workerState{
+			worker: wk,
+		}
+
+		fw.workers[parentPath] = ws
+	}
+
+	return ws, cleanedPath, parentPath, nil
+}
+
+func (fw *fileWatcher) findWorker(path string) (*workerState, string, error) {
+	if fw.workers == nil {
+		return nil, "", errors.New("using a closed watcher")
+	}
+
+	cleanedPath := filepath.Clean(path)
+	parentPath, _ := filepath.Split(cleanedPath)
+
+	ws, workerExists := fw.workers[parentPath]
+	if !workerExists {
+		return nil, "", fmt.Errorf("no path registered for %s", path)
+	}
+
+	return ws, cleanedPath, nil
 }

--- a/filewatcher/worker.go
+++ b/filewatcher/worker.go
@@ -1,0 +1,220 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filewatcher
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type worker struct {
+	mu sync.RWMutex
+
+	// watcher is an fsnotify watcher that watches the parent
+	// dir of watchedFiles.
+	dirWatcher *fsnotify.Watcher
+
+	// The worker maintain a map of channels keyed by watched file path.
+	// The worker watches parent path of given path,
+	// and filters out events of given path, then redirect
+	// to the result channel.
+	// Note that for symlink files, the content in received events
+	// do not have to be related to the file itself.
+	watchedFiles map[string]*fileTracker
+
+	// add a new path to watch
+	addPathCh chan string
+
+	// remove a path
+	removePathCh chan string
+
+	// tells the worker to exit
+	terminateCh chan bool
+
+	// synchronize with worker activity
+	barrierCh chan bool
+}
+
+type fileTracker struct {
+	events chan fsnotify.Event
+	errors chan error
+
+	// md5 sum to indicate if a file has been updated.
+	md5Sum []byte
+}
+
+func newWorker(path string) (*worker, error) {
+	dirWatcher, err := funcs.newWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = funcs.addWatcherPath(dirWatcher, path); err != nil {
+		_ = dirWatcher.Close()
+		return nil, err
+	}
+
+	wk := &worker{
+		dirWatcher:   dirWatcher,
+		watchedFiles: make(map[string]*fileTracker),
+		addPathCh:    make(chan string),
+		removePathCh: make(chan string),
+		terminateCh:  make(chan bool),
+		barrierCh:    make(chan bool),
+	}
+
+	go wk.loop()
+
+	return wk, nil
+}
+
+func (wk *worker) loop() {
+	for {
+		select {
+		case event := <-wk.dirWatcher.Events:
+			for path, ft := range wk.watchedFiles {
+				sum := getMd5Sum(path)
+				if !bytes.Equal(sum, ft.md5Sum) {
+					ft.md5Sum = sum
+					ft.events <- event
+				}
+			}
+
+		case err := <-wk.dirWatcher.Errors:
+			for _, ft := range wk.watchedFiles {
+				ft.errors <- err
+			}
+
+		case path := <-wk.addPathCh:
+			ft := wk.watchedFiles[path]
+			if ft != nil {
+				funcs.panic(fmt.Sprintf("can't watch the %s path multiple times", path))
+				break
+			}
+
+			ft = &fileTracker{
+				events: make(chan fsnotify.Event),
+				errors: make(chan error),
+				md5Sum: getMd5Sum(path),
+			}
+
+			wk.mu.Lock()
+			wk.watchedFiles[path] = ft
+			wk.mu.Unlock()
+
+		case path := <-wk.removePathCh:
+			ft := wk.watchedFiles[path]
+			if ft == nil {
+				funcs.panic(fmt.Sprintf("can't stop watching the %s path as it wasn't being watched", path))
+				break
+			}
+
+			wk.mu.Lock()
+			delete(wk.watchedFiles, path)
+			wk.mu.Unlock()
+			close(ft.errors)
+			close(ft.events)
+
+		case <-wk.terminateCh:
+			for _, ft := range wk.watchedFiles {
+				close(ft.errors)
+				close(ft.events)
+			}
+
+			_ = wk.dirWatcher.Close()
+			close(wk.addPathCh)
+			close(wk.removePathCh)
+			close(wk.terminateCh)
+			close(wk.barrierCh)
+			return
+
+		case <-wk.barrierCh:
+			// nothing to do
+		}
+	}
+}
+
+func (wk *worker) terminate() {
+	wk.terminateCh <- true
+}
+
+func (wk *worker) addPath(path string) {
+	wk.addPathCh <- path
+}
+
+func (wk *worker) removePath(path string) {
+	wk.removePathCh <- path
+}
+
+func (wk *worker) eventChannel(path string) chan fsnotify.Event {
+	// Ensure any previous add/remove has completed
+	//
+	// Since we're using blocking channels, the caller blocks when adding or removing a path
+	// until the worker goroutine has woken up and started processing the path. Poking this
+	// barrier will block until the worker can get around to reading the message from the channel,
+	// which indirectly ensures that a previous addPath/removePath has already completed and so the
+	// event and error channels have been created
+	wk.barrierCh <- true
+
+	wk.mu.RLock()
+	defer wk.mu.RUnlock()
+
+	if ft, ok := wk.watchedFiles[path]; ok {
+		return ft.events
+	}
+
+	return nil
+}
+
+func (wk *worker) errorChannel(path string) chan error {
+	// Ensure any previous add/remove has completed
+	//
+	// Since we're using blocking channels, the caller blocks when adding or removing a path
+	// until the worker goroutine has woken up and started processing the path. Poking this
+	// barrier will block until the worker can get around to reading the message from the channel,
+	// which indirectly ensures that a previous addPath/removePath has already completed and so the
+	// event and error channels have been created
+	wk.barrierCh <- true
+
+	wk.mu.RLock()
+	defer wk.mu.RUnlock()
+
+	if ft, ok := wk.watchedFiles[path]; ok {
+		return ft.errors
+	}
+
+	return nil
+}
+
+// gets the MD5 of the given file, or nil if there's a problem
+func getMd5Sum(file string) []byte {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	r := bufio.NewReader(f)
+
+	h := md5.New()
+	_, _ = io.Copy(h, r)
+	return h.Sum(nil)
+}


### PR DESCRIPTION
This reimplements the file watcher functionality to try and systematically eliminate the inherent race conditions in the previous design. There are some minor semantic changes:

- The FileWatcher.Add call now panics when called multiple times for the same path.

- The FileWatcher.Remove call now panics when called for an unknown path.

- It's now possible to watch a file that doesn't exist. Events will be generated when the file is created/deleted over time.

Code coverage was boosted to 98.3%.

This PR incorporates some of the changes from https://github.com/istio/pkg/pull/57
Fixes https://github.com/istio/istio/issues/15987
