### PR TITLE
Dataplane versions

### DIFF
--- a/version/cobra.go
+++ b/version/cobra.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -25,13 +26,14 @@ import (
 
 // Version holds info for client and control plane versions
 type Version struct {
-	ClientVersion *BuildInfo `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
-	MeshVersion   *MeshInfo  `json:"meshVersion,omitempty" yaml:"meshVersion,omitempty"`
+	ClientVersion    *BuildInfo   `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	MeshVersion      *MeshInfo    `json:"meshVersion,omitempty" yaml:"meshVersion,omitempty"`
+	DataPlaneVersion *[]ProxyInfo `json:"dataPlaneVersion,omitempty" yaml:"dataPlaneVersion,omitempty"`
 }
 
 // GetRemoteVersionFunc is the function protoype to be passed to CobraOptions so that it is
 // called when invoking `cmd version`
-type GetRemoteVersionFunc func() (*MeshInfo, error)
+type GetRemoteVersionFunc func() (*MeshInfo, *[]ProxyInfo, error)
 
 // CobraOptions holds options to be passed to `CobraCommandWithOptions`
 type CobraOptions struct {
@@ -69,7 +71,7 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 			version.ClientVersion = &Info
 
 			if options.GetRemoteVersion != nil && remote {
-				remoteVersion, serverErr = options.GetRemoteVersion()
+				remoteVersion, version.DataPlaneVersion, serverErr = options.GetRemoteVersion()
 				version.MeshVersion = remoteVersion
 			}
 
@@ -86,6 +88,9 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 					} else {
 						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.Version)
 					}
+					if version.DataPlaneVersion != nil {
+						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "data plane version: %s\n", renderProxyVersions(version.DataPlaneVersion))
+					}
 				} else {
 					if remoteVersion != nil {
 						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.LongForm())
@@ -94,6 +99,11 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 						}
 					} else {
 						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.LongForm())
+					}
+					if version.DataPlaneVersion != nil {
+						for _, proxy := range *version.DataPlaneVersion {
+							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "data plane version: %#v\n", proxy)
+						}
 					}
 				}
 			case "yaml":
@@ -145,4 +155,22 @@ func identicalVersions(remoteVersion MeshInfo) bool {
 	}
 
 	return true
+}
+
+// renderProxyVersions produces human-readable summary of an array of sidecar Istio versions
+func renderProxyVersions(pinfos *[]ProxyInfo) string {
+	if len(*pinfos) == 0 {
+		return "none"
+	}
+
+	versions := make(map[string][]string)
+	for _, pinfo := range *pinfos {
+		ids := versions[pinfo.IstioVersion]
+		versions[pinfo.IstioVersion] = append(ids, pinfo.ID)
+	}
+	counts := []string{}
+	for ver, ids := range versions {
+		counts = append(counts, fmt.Sprintf("%s: (%d proxies)", ver, len(ids)))
+	}
+	return strings.Join(counts, ", ")
 }

--- a/version/cobra.go
+++ b/version/cobra.go
@@ -33,7 +33,8 @@ type Version struct {
 
 // GetRemoteVersionFunc is the function protoype to be passed to CobraOptions so that it is
 // called when invoking `cmd version`
-type GetRemoteVersionFunc func() (*MeshInfo, *[]ProxyInfo, error)
+type GetRemoteVersionFunc func() (*MeshInfo, error)
+type GetProxyVersionFunc func() (*[]ProxyInfo, error)
 
 // CobraOptions holds options to be passed to `CobraCommandWithOptions`
 type CobraOptions struct {
@@ -41,6 +42,7 @@ type CobraOptions struct {
 	// Istio components. Optional. If not set, the 'version' subcommand will not attempt
 	// to connect to a remote side, and CLI flags such as '--remote' will be hidden.
 	GetRemoteVersion GetRemoteVersionFunc
+	GetProxyVersions GetProxyVersionFunc
 }
 
 // CobraCommand returns a command used to print version information.
@@ -71,8 +73,11 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 			version.ClientVersion = &Info
 
 			if options.GetRemoteVersion != nil && remote {
-				remoteVersion, version.DataPlaneVersion, serverErr = options.GetRemoteVersion()
+				remoteVersion, serverErr = options.GetRemoteVersion()
 				version.MeshVersion = remoteVersion
+			}
+			if options.GetProxyVersions != nil && remote {
+				version.DataPlaneVersion, _ = options.GetProxyVersions()
 			}
 
 			switch output {

--- a/version/cobra_test.go
+++ b/version/cobra_test.go
@@ -29,7 +29,7 @@ import (
 func TestOpts(t *testing.T) {
 	ordinaryCmd := CobraCommand()
 	remoteCmd := CobraCommandWithOptions(
-		CobraOptions{GetRemoteVersion: mockRemoteMesh(&meshInfoMultiVersion, nil)})
+		CobraOptions{GetRemoteVersion: mockRemoteMesh(&meshInfoMultiVersion)})
 
 	cases := []struct {
 		args       string
@@ -118,9 +118,9 @@ var meshInfoMultiVersion = MeshInfo{
 	{"Citadel", BuildInfo{"1.2", "gitSHA321", "go1.11.0", "Clean", "1.2"}},
 }
 
-func mockRemoteMesh(meshInfo *MeshInfo, proxyInfo *[]ProxyInfo) GetRemoteVersionFunc {
-	return func() (*MeshInfo, *[]ProxyInfo, error) {
-		return meshInfo, proxyInfo, nil
+func mockRemoteMesh(meshInfo *MeshInfo) GetRemoteVersionFunc {
+	return func() (*MeshInfo, error) {
+		return meshInfo, nil
 	}
 }
 
@@ -255,7 +255,7 @@ control plane version: 1.2.0
 
 	for i, v := range cases {
 		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(v.args, " ")), func(t *testing.T) {
-			cmd := CobraCommandWithOptions(CobraOptions{GetRemoteVersion: mockRemoteMesh(v.remoteMesh, nil)})
+			cmd := CobraCommandWithOptions(CobraOptions{GetRemoteVersion: mockRemoteMesh(v.remoteMesh)})
 			var out bytes.Buffer
 			cmd.SetOutput(&out)
 			cmd.SetArgs(v.args)

--- a/version/cobra_test.go
+++ b/version/cobra_test.go
@@ -29,7 +29,7 @@ import (
 func TestOpts(t *testing.T) {
 	ordinaryCmd := CobraCommand()
 	remoteCmd := CobraCommandWithOptions(
-		CobraOptions{GetRemoteVersion: mockRemoteMesh(&meshInfoMultiVersion)})
+		CobraOptions{GetRemoteVersion: mockRemoteMesh(&meshInfoMultiVersion, nil)})
 
 	cases := []struct {
 		args       string
@@ -118,9 +118,9 @@ var meshInfoMultiVersion = MeshInfo{
 	{"Citadel", BuildInfo{"1.2", "gitSHA321", "go1.11.0", "Clean", "1.2"}},
 }
 
-func mockRemoteMesh(meshInfo *MeshInfo) GetRemoteVersionFunc {
-	return func() (*MeshInfo, error) {
-		return meshInfo, nil
+func mockRemoteMesh(meshInfo *MeshInfo, proxyInfo *[]ProxyInfo) GetRemoteVersionFunc {
+	return func() (*MeshInfo, *[]ProxyInfo, error) {
+		return meshInfo, proxyInfo, nil
 	}
 }
 
@@ -255,7 +255,7 @@ control plane version: 1.2.0
 
 	for i, v := range cases {
 		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(v.args, " ")), func(t *testing.T) {
-			cmd := CobraCommandWithOptions(CobraOptions{GetRemoteVersion: mockRemoteMesh(v.remoteMesh)})
+			cmd := CobraCommandWithOptions(CobraOptions{GetRemoteVersion: mockRemoteMesh(v.remoteMesh, nil)})
 			var out bytes.Buffer
 			cmd.SetOutput(&out)
 			cmd.SetArgs(v.args)

--- a/version/version.go
+++ b/version/version.go
@@ -48,6 +48,12 @@ type ServerInfo struct {
 // MeshInfo contains the versions for all Istio control plane components
 type MeshInfo []ServerInfo
 
+// ProxyInfo contains the version for a single data plane component
+type ProxyInfo struct {
+	ID           string
+	IstioVersion string
+}
+
 // NewBuildInfoFromOldString creates a BuildInfo struct based on the output
 // of previous Istio components '-- version' output
 func NewBuildInfoFromOldString(oldOutput string) (BuildInfo, error) {


### PR DESCRIPTION
Provides the hooks to output the data plane versions (Istio versions of the sidecar).

This is part of the implementation of https://github.com/istio/istio/issues/17172 .  To be complete, a second PR is needed in istio/istio to add the actual function (I have that one ready).

This PR does not yet include the tests.

@howardjohn If this implementation looks clean enough I will write the tests and push my PR that adds the proxy gathering to istio/istio.