### PR TITLE
Fix cache segfaults due to unaligned atomics on 32b architectures

### DIFF
--- a/cache/lruCache.go
+++ b/cache/lruCache.go
@@ -244,7 +244,7 @@ func (c *lruCache) SetWithExpiration(key interface{}, value interface{}, expirat
 	ent.value = value
 	ent.expiration = exp
 
-	atomic.AddUint64(&c.stats.Writes, 1)
+	c.stats.Writes++
 
 	c.Unlock()
 }

--- a/cache/ttlCache.go
+++ b/cache/ttlCache.go
@@ -40,11 +40,13 @@ type ttlWrapper struct {
 }
 
 type ttlCache struct {
+	// baseTimeNanos must be at start of struct to ensure 64bit alignment for atomics on
+	// 32bit architectures. See also: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	baseTimeNanos     int64
 	entries           sync.Map
 	stats             Stats
 	defaultExpiration time.Duration
 	stopEvicter       chan bool
-	baseTimeNanos     int64
 	evicterTerminated sync.WaitGroup // used by unit tests to verify the finalizer ran
 	callback          EvictionCallback
 }


### PR DESCRIPTION
Environment where the issue was encountered:
- Raspberry Pi 4: `Linux pi-03 4.19.66-v7l+ #1253 SMP Thu Aug 15 12:02:08 BST 2019 armv7l GNU/Linux`
- Go version 1.13.1

Per the [atomic library docs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):
> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

---

I was able to reproduce the segfault with the following test code (`main.go`):
```
package main

import (
	"fmt"
	"time"
	"istio.io/pkg/cache"
)

func set(c cache.Cache, k string, v string) {
	fmt.Printf("Setting %v => %v\n", k, v)
	c.Set(k, v)
}

func get(c cache.Cache, k string) {
	v, ok := c.Get(k)
    if ok {
        fmt.Printf("%v=%v\n", k, v)
    } else {
        fmt.Printf("%v not found\n", k)
    }
}

func test(c cache.Cache) {
	set(c, "one", "foo")

	get(c, "one")
	get(c, "two")

	// Trigger size-based eviction
	set(c, "two", "bar")

	get(c, "one")
	get(c, "two")

	// Trigger TTL-based eviction
	fmt.Printf("Waiting for expiry...\n")
	time.Sleep(1500 * time.Millisecond)

	get(c, "one")
	get(c, "two")
}

func main() {
	fmt.Printf("*** LRU ***\n")
	test(cache.NewLRU(1 * time.Second, 1 * time.Second, 1))

	fmt.Printf("\n*** TTL ***\n")
	test(cache.NewTTL(1 * time.Second, 1 * time.Second))

	fmt.Printf("\n*** PASS ***\n")
}
```

The above can be built as a static ARM7 binary via the following `go build` command:
```
CGO_ENABLED=0 GOARCH=arm GOOS=linux go build -ldflags="-s"
```

---

Error 1: atomic increment of unaligned within lock in `lruCache.go`, fix was to just remove the atomic increment since it's within a lock and none of the other stats do this:

```
# ./main 
*** LRU ***
Setting one => foo
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11da0]

goroutine 1 [running]:
runtime/internal/atomic.goXadd64(0x188402c, 0x1, 0x0, 0x186a4a8, 0x1866100)
	/usr/lib/go/src/runtime/internal/atomic/atomic_arm.go:103 +0x1c
istio.io/pkg/cache.(*lruCache).SetWithExpiration(0x1884000, 0xc1280, 0x1866128, 0xc1280, 0x1866130, 0x3b9aca00, 0x0)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/cache/lruCache.go:247 +0x1bc
istio.io/pkg/cache.(*lruCache).Set(0x1884000, 0xc1280, 0x1866128, 0xc1280, 0x1866130)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/cache/lruCache.go:224 +0x4c
main.set(0xa6d22008, 0x1866110, 0xd6946, 0x3, 0xd6931, 0x3)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:11 +0x108
main.test(0xa6d22008, 0x1866110)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:24 +0x40
main.main()
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:45 +0xa0
```

---

Error 2:  unaligned `baseTimeNanos` in `ttlCache.go`, fix was to move the value to the start of the type to ensure alignment as recommended by `atomic` docs:

```
# ./main 
*** LRU ***
Setting one => foo
one=foo
two not found
Setting two => bar
one not found
two=bar
Waiting for expiry...
one not found
two not found

*** TTL ***
Setting one => foo
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11f68]

goroutine 1 [running]:
runtime/internal/atomic.goLoad64(0x89e04c, 0x16c618, 0xd1850)
	/usr/lib/go/src/runtime/internal/atomic/atomic_arm.go:131 +0x1c
istio.io/pkg/cache.(*ttlCache).SetWithExpiration(0x89e000, 0xc1280, 0x88e040, 0xc1280, 0x88e048, 0x3b9aca00, 0x0)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/cache/ttlCache.go:173 +0x24
istio.io/pkg/cache.(*ttlCache).Set(0x89e000, 0xc1280, 0x88e040, 0xc1280, 0x88e048)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/cache/ttlCache.go:167 +0x4c
main.set(0xa6c37008, 0x88e028, 0xd6946, 0x3, 0xd6931, 0x3)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:11 +0x108
main.test(0xa6c37008, 0x88e028)
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:24 +0x40
main.main()
	/home/nick/code/pkg/.gopath/src/istio.io/pkg/main/main.go:48 +0x12c
```

---

After both fixes:

```
# ./main 
*** LRU ***
Setting one => foo
one=foo
two not found
Setting two => bar
one not found
two=bar
Waiting for expiry...
one not found
two not found

*** TTL ***
Setting one => foo
one=foo
two not found
Setting two => bar
one=foo
two=bar
Waiting for expiry...
one not found
two not found

*** PASS ***
```