### PR TITLE
Improve HTML collateral output.

### DIFF
--- a/collateral/control.go
+++ b/collateral/control.go
@@ -432,6 +432,7 @@ func (g *generator) genFrontMatter(root *cobra.Command, numEntries int) {
 	g.emit("description: ", root.Short)
 	g.emit("generator: pkg-collateral-docs")
 	g.emit("number_of_entries: ", strconv.Itoa(numEntries))
+	g.emit("force_inline_toc: true")
 	g.emit("---")
 }
 


### PR DESCRIPTION
Force the TOC for command pages to be inserted inline rather than
being in the right margin.