### PR TITLE
A fix for an issue istioctl version throws the 'index out of range' panic if a user does not have the 'pods/exec' permission

### DIFF
--- a/version/cobra.go
+++ b/version/cobra.go
@@ -74,6 +74,9 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 
 			if options.GetRemoteVersion != nil && remote {
 				remoteVersion, serverErr = options.GetRemoteVersion()
+				if serverErr != nil {
+					return serverErr
+				}
 				version.MeshVersion = remoteVersion
 			}
 			if options.GetProxyVersions != nil && remote {
@@ -121,7 +124,7 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 				}
 			}
 
-			return serverErr
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/18925

`serverErr` is returned to late in the affected code. If a Kubernetes user does not have the "pods/exec" permission, then `options.GetRemoteVersion()` return an empty `remoteVersion` array and a multi-error `serverErr` which contains all permissions errors. So a subsequent `identicalVersions` function calls empty array `remoteVersion[0].Info` and throws the panic

```
panic: runtime error: index out of range

goroutine 1 [running]:
istio.io/istio/vendor/istio.io/pkg/version.identicalVersions(0x4708070, 0x0, 0x0, 0x2)
        /workspace/go/src/istio.io/istio/vendor/istio.io/pkg/version/cobra.go:136 +0x142
istio.io/istio/vendor/istio.io/pkg/version.coalesceVersions(...)
        /workspace/go/src/istio.io/istio/vendor/istio.io/pkg/version/cobra.go:123
istio.io/istio/vendor/istio.io/pkg/version.CobraCommandWithOptions.func1(0xc00051a280, 0x4708070, 0x0, 0x0, 0x0, 0x0)
        /workspace/go/src/istio.io/istio/vendor/istio.io/pkg/version/cobra.go:80 +0x115
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).execute(0xc00051a280, 0x4708070, 0x0, 0x0, 0xc00051a280, 0x4708070)
        /workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:762 +0x46c
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc00051a000, 0x1, 0x1, 0xc00051a000)
        /workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:852 +0x2f3
istio.io/istio/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        /workspace/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:800
main.main()
        /workspace/go/src/istio.io/istio/istioctl/cmd/istioctl/main.go:28 +0x7c
```

I moved the `return serverErr` statement right after the `options.GetRemoteVersion()` call and added a unit test for the case.