### PR TITLE
Use local time in write log to look it comfortably

### DIFF
--- a/log/config.go
+++ b/log/config.go
@@ -167,7 +167,7 @@ func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer,
 }
 
 func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	t = t.UTC()
+	t = t.Local()
 	year, month, day := t.Date()
 	hour, minute, second := t.Clock()
 	micros := t.Nanosecond() / 1000


### PR DESCRIPTION
Use local time is better, when match other local time log system.