### PR TITLE
fix race between ExportMetrics and ExportView

### DIFF
--- a/collateral/metrics/opencensus.go
+++ b/collateral/metrics/opencensus.go
@@ -60,11 +60,12 @@ func (r *OpenCensusRegistry) ExportView(d *view.Data) {
 
 func (r *OpenCensusRegistry) ExportedMetrics() []Exported {
 	r.RLock()
+	defer r.RUnlock()
+
 	names := []string{}
 	for key := range r.metrics {
 		names = append(names, key)
 	}
-	r.RUnlock()
 
 	sort.Strings(names)
 


### PR DESCRIPTION
This race was detected in CI. I could only reproduce it on my workstation by inserting a sleep in `ExportView` while the lock is held.   