### PR TITLE
add log_utc_time_zone flag for utc time zone

### DIFF
--- a/log/config.go
+++ b/log/config.go
@@ -167,7 +167,6 @@ func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer,
 }
 
 func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	t = t.UTC()
 	year, month, day := t.Date()
 	hour, minute, second := t.Clock()
 	micros := t.Nanosecond() / 1000
@@ -217,6 +216,11 @@ func updateScopes(options *Options) error {
 	// update the stack tracing levels of all listed scopes
 	if err := processLevels(allScopes, options.stackTraceLevels, func(s *Scope, l Level) { s.SetStackTraceLevel(l) }); err != nil {
 		return err
+	}
+
+	// update the log utc of all listed scopes
+	for _, scope := range allScopes {
+		scope.SetUTCTimeZone(options.UTCTimeZone)
 	}
 
 	// update the caller location setting of all listed scopes

--- a/log/options.go
+++ b/log/options.go
@@ -111,6 +111,9 @@ type Options struct {
 	// JSONEncoding controls whether the log is formatted as JSON.
 	JSONEncoding bool
 
+	// UTCTimeZone controls whether to use UTC or local time zone.
+	UTCTimeZone bool
+
 	// LogGrpc indicates that Grpc logs should be captured. The default is true.
 	// This is not exposed through the command-line flags, as this flag is mainly useful for testing: Grpc
 	// stack will hold on to the logger even though it gets closed. This causes data races.
@@ -131,6 +134,7 @@ func DefaultOptions() *Options {
 		RotationMaxBackups: defaultRotationMaxBackups,
 		outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
 		stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+		UTCTimeZone:        true,
 		LogGrpc:            true,
 	}
 }
@@ -343,6 +347,9 @@ func (o *Options) AttachFlags(
 
 	boolVar(&o.JSONEncoding, "log_as_json", o.JSONEncoding,
 		"Whether to format output as JSON or in plain console-friendly format")
+
+	boolVar(&o.UTCTimeZone, "log_utc_time_zone", o.UTCTimeZone,
+		"Whether to use UTC time zone or local.")
 
 	levelListString := fmt.Sprintf("[%s, %s, %s, %s, %s, %s]",
 		levelToString[DebugLevel],

--- a/log/options_test.go
+++ b/log/options_test.go
@@ -30,6 +30,30 @@ func TestOpts(t *testing.T) {
 		cmdLine string
 		result  Options
 	}{
+		{"--log_utc_time_zone", Options{
+			OutputPaths:        []string{defaultOutputPath},
+			ErrorOutputPaths:   []string{defaultErrorOutputPath},
+			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
+			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:     defaultRotationMaxAge,
+			RotationMaxSize:    defaultRotationMaxSize,
+			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
+			LogGrpc:            true,
+		}},
+
+		{"--log_utc_time_zone=false", Options{
+			OutputPaths:        []string{defaultOutputPath},
+			ErrorOutputPaths:   []string{defaultErrorOutputPath},
+			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
+			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:     defaultRotationMaxAge,
+			RotationMaxSize:    defaultRotationMaxSize,
+			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        false,
+			LogGrpc:            true,
+		}},
+
 		{"--log_as_json", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
@@ -39,6 +63,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -50,6 +75,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -62,6 +88,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -73,6 +100,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -84,6 +112,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -95,6 +124,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -106,6 +136,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -117,6 +148,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -128,6 +160,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -139,6 +172,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -150,6 +184,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -161,6 +196,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -172,6 +208,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -183,6 +220,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -194,6 +232,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -205,6 +244,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -216,6 +256,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -227,6 +268,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -239,6 +281,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -250,6 +293,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     1234,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -261,6 +305,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    1234,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 
@@ -272,6 +317,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: 1234,
+			UTCTimeZone:        true,
 			LogGrpc:            true,
 		}},
 	}

--- a/log/scope_test.go
+++ b/log/scope_test.go
@@ -27,12 +27,13 @@ func TestBasicScopes(t *testing.T) {
 	s := RegisterScope("testScope", "z", 0)
 
 	cases := []struct {
-		f          func()
-		pat        string
-		json       bool
-		caller     bool
-		wantExit   bool
-		stackLevel Level
+		f           func()
+		pat         string
+		json        bool
+		caller      bool
+		wantExit    bool
+		stackLevel  Level
+		utcTimeZone bool
 	}{
 		{
 			f:   func() { s.Debug("Hello") },
@@ -133,17 +134,19 @@ func TestBasicScopes(t *testing.T) {
 			f: func() { s.Debug("Hello") },
 			pat: "{\"level\":\"debug\",\"time\":\"" + timePattern + "\",\"scope\":\"testScope\",\"caller\":\"log/scope_test.go:.*\",\"msg\":\"Hello\"," +
 				"\"stack\":\".*\"}",
-			json:       true,
-			caller:     true,
-			stackLevel: DebugLevel,
+			json:        true,
+			caller:      true,
+			stackLevel:  DebugLevel,
+			utcTimeZone: true,
 		},
 		{
 			f: func() { s.Info("Hello") },
 			pat: "{\"level\":\"info\",\"time\":\"" + timePattern + "\",\"scope\":\"testScope\",\"caller\":\"log/scope_test.go:.*\",\"msg\":\"Hello\"," +
 				"\"stack\":\".*\"}",
-			json:       true,
-			caller:     true,
-			stackLevel: DebugLevel,
+			json:        true,
+			caller:      true,
+			stackLevel:  DebugLevel,
+			utcTimeZone: true,
 		},
 		{
 			f: func() { s.Warn("Hello") },
@@ -158,19 +161,21 @@ func TestBasicScopes(t *testing.T) {
 			pat: "{\"level\":\"error\",\"time\":\"" + timePattern + "\",\"scope\":\"testScope\",\"caller\":\"log/scope_test.go:.*\"," +
 				"\"msg\":\"Hello\"," +
 				"\"stack\":\".*\"}",
-			json:       true,
-			caller:     true,
-			stackLevel: DebugLevel,
+			json:        true,
+			caller:      true,
+			stackLevel:  DebugLevel,
+			utcTimeZone: true,
 		},
 		{
 			f: func() { s.Fatal("Hello") },
 			pat: "{\"level\":\"fatal\",\"time\":\"" + timePattern + "\",\"scope\":\"testScope\",\"caller\":\"log/scope_test.go:.*\"," +
 				"\"msg\":\"Hello\"," +
 				"\"stack\":\".*\"}",
-			json:       true,
-			caller:     true,
-			wantExit:   true,
-			stackLevel: DebugLevel,
+			json:        true,
+			caller:      true,
+			wantExit:    true,
+			stackLevel:  DebugLevel,
+			utcTimeZone: true,
 		},
 	}
 
@@ -194,6 +199,7 @@ func TestBasicScopes(t *testing.T) {
 				s.SetOutputLevel(DebugLevel)
 				s.SetStackTraceLevel(c.stackLevel)
 				s.SetLogCallers(c.caller)
+				s.SetUTCTimeZone(c.utcTimeZone)
 
 				c.f()
 				_ = Sync()


### PR DESCRIPTION
Issue Desc:
1.  time.Now() // local time zone
2. t.UTC() // set utc time zone
3. log output utc time zone and can't use local time zone.

fix:
1. add log_utc_time_zone flag.
2. --log_utc_time_zone=true // default &&  set UTC time zone.
3. --log_utc_time_zone=false // set location time zone.