### PR TITLE
Add support for wrapping structured.Error with %w

### DIFF
--- a/log/default_test.go
+++ b/log/default_test.go
@@ -237,7 +237,7 @@ func TestErrorDictionary(t *testing.T) {
 		t.Errorf("Got error '%v', expected success", err)
 	}
 
-	expected := "Hello	moreInfo=MoreInfo impact=Impact action=Action likelyCauses=LikelyCause"
+	expected := "Hello	moreInfo=MoreInfo impact=Impact action=Action likelyCause=LikelyCause"
 	if match, _ := regexp.MatchString(expected, lines[0]); !match {
 		t.Errorf("Got '%v', expected a match with '%v'", lines[0], expected)
 	}

--- a/log/scope_test.go
+++ b/log/scope_test.go
@@ -321,7 +321,8 @@ func TestScopeErrorDictionaryWrap(t *testing.T) {
 		t.Errorf("Got error '%v', expected success", err)
 	}
 
-	mustRegexMatchString(t, lines[0], "Hello: func2 prefix: \tmoreInfo=someMoreInfo impact=someImpact action=someAction likelyCause=someLikelyCause err=someErr\tfoo=bar")
+	mustRegexMatchString(t, lines[0], "Hello: func2 prefix: "+
+		"\tmoreInfo=someMoreInfo impact=someImpact action=someAction likelyCause=someLikelyCause err=someErr\tfoo=bar")
 }
 
 // func2 is used to test correct error return through %w verb.

--- a/log/zapcore_handler.go
+++ b/log/zapcore_handler.go
@@ -63,7 +63,8 @@ func ZapLogHandlerCallbackFunc(
 			fields = appendNotEmptyField(fields, "moreInfo", ie.MoreInfo)
 			fields = appendNotEmptyField(fields, "impact", ie.Impact)
 			fields = appendNotEmptyField(fields, "action", ie.Action)
-			fields = appendNotEmptyField(fields, "likelyCauses", ie.LikelyCause)
+			fields = appendNotEmptyField(fields, "likelyCause", ie.LikelyCause)
+			fields = appendNotEmptyField(fields, "err", toErrString(ie.Err))
 		}
 		for _, k := range scope.labelKeys {
 			v := scope.labels[k]
@@ -83,7 +84,8 @@ func ZapLogHandlerCallbackFunc(
 			appendNotEmptyString(sb, "moreInfo", ie.MoreInfo)
 			appendNotEmptyString(sb, "impact", ie.Impact)
 			appendNotEmptyString(sb, "action", ie.Action)
-			appendNotEmptyString(sb, "likelyCauses", ie.LikelyCause)
+			appendNotEmptyString(sb, "likelyCause", ie.LikelyCause)
+			appendNotEmptyString(sb, "err", toErrString(ie.Err))
 		}
 		space := false
 		for _, k := range scope.labelKeys {
@@ -100,7 +102,7 @@ func ZapLogHandlerCallbackFunc(
 
 // appendNotEmptyField appends a field with key:value to fields. If value is empty, it does nothing.
 func appendNotEmptyField(fields []zapcore.Field, key, value string) []zapcore.Field {
-	if key == "" {
+	if key == "" || value == "" {
 		return fields
 	}
 	return append(fields, zap.String(key, value))
@@ -108,7 +110,7 @@ func appendNotEmptyField(fields []zapcore.Field, key, value string) []zapcore.Fi
 
 // appendNotEmptyString appends a key=value string to sb. If value is empty, it does nothing.
 func appendNotEmptyString(sb *strings.Builder, key, value string) {
-	if key == "" {
+	if key == "" || value == "" {
 		return
 	}
 	sb.WriteString(fmt.Sprintf("%s=%v ", key, value))
@@ -174,4 +176,12 @@ func emit(scope *Scope, level zapcore.Level, msg string, fields []zapcore.Field)
 // backwards compatibility. TODO(mostrowski): remove this
 func (s *Scope) emit(level zapcore.Level, ps bool, msg string, fields []zapcore.Field) {
 	emit(s, level, msg, fields)
+}
+
+// toErrString returns the string representation of err, handling the nil case.
+func toErrString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }

--- a/structured/structured.go
+++ b/structured/structured.go
@@ -14,6 +14,10 @@
 
 package structured
 
+import (
+	"fmt"
+)
+
 // Error represents structured error information, for optional use in scope.X or log.X calls.
 // It is not the same thing as structured logging. The "structured" here means adding a structure to user facing
 // messages.
@@ -27,4 +31,26 @@ type Error struct {
 	Action string
 	// LikelyCause is the likely cause for the error e.g. "Software bug."
 	LikelyCause string
+	// Err is the original error string.
+	Err error
 }
+
+// Error implements the error#Error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("\tmoreInfo=%s impact=%s action=%s likelyCause=%s err=%v",
+		e.MoreInfo, e.Impact, e.Action, e.LikelyCause, e.Err)
+}
+
+// NewErr creates a new copy of an Error with the content of serr and err and returns a ptr to it.
+func NewErr(serr *Error, err error) *Error {
+	// Make a copy so that dictionary entry is not modified.
+	ne := *serr
+	ne.Err = err
+	return &ne
+}
+
+// Unwrap implements error unwrapping for %w verb.
+func (e *Error) Unwrap() error { return e }


### PR DESCRIPTION
This PR implements %w wrapping for cases where structured.Error needs to be returned as an error from a function. 
See https://blog.golang.org/go1.13-errors for background on %w. 
This redoes the work in https://github.com/istio/pkg/pull/215 with some important differences:
- no special parsing required to extract fields for handlers
- caller is responsible for explicitly extracting structured.Error before calling scope.