### PR TITLE
klog: fix formatting of kv pairs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,5 +46,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.7
 	gotest.tools v2.2.0+incompatible
 	istio.io/api v0.0.0-20190515205759-982e5c3888c6
-	k8s.io/klog/v2 v2.3.0
+	k8s.io/klog/v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -266,5 +266,5 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6 h1:lnDXeR6NYxT+Rfa5jKE1CpMfStnJ36/bYOSziS8dubU=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
-k8s.io/klog/v2 v2.3.0 h1:WmkrnW7fdrm0/DMClc+HIxtftvxVIPAhlVwMQo5yLco=
-k8s.io/klog/v2 v2.3.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
+k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
+k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/log/logr.go
+++ b/log/logr.go
@@ -60,18 +60,18 @@ func trimNewline(msg string) string {
 
 func (zl *zapLogger) Info(msg string, keysAndVals ...interface{}) {
 	if zl.lvlSet && zl.lvl > debugLevelThreshold {
-		zl.l.Debug(trimNewline(msg), keysAndVals)
+		zl.l.WithLabels(keysAndVals...).Debug(trimNewline(msg))
 	} else {
-		zl.l.Info(trimNewline(msg), keysAndVals)
+		zl.l.WithLabels(keysAndVals...).Info(trimNewline(msg))
 	}
 }
 
 func (zl *zapLogger) Error(err error, msg string, keysAndVals ...interface{}) {
 	if zl.l.ErrorEnabled() {
 		if err == nil {
-			zl.l.Error(trimNewline(msg), keysAndVals)
+			zl.l.WithLabels(keysAndVals...).Error(trimNewline(msg))
 		} else {
-			zl.l.Error(fmt.Sprintf("%v: %s", err.Error(), msg), keysAndVals)
+			zl.l.WithLabels(keysAndVals...).Error(fmt.Sprintf("%v: %s", err.Error(), msg))
 		}
 	}
 }

--- a/log/scope_test.go
+++ b/log/scope_test.go
@@ -81,7 +81,7 @@ func TestKlog(t *testing.T) {
 			"error\tklog\tmy error: info\tkey=1",
 		},
 	}
-	for _, tt := range cases[6:] {
+	for _, tt := range cases {
 		t.Run(tt.expected, func(t *testing.T) {
 			lines := runTest(t, tt.log)
 			mustMatchLength(t, 1, lines)


### PR DESCRIPTION
Previously we would write the pairs as a list at hte end of the message.
In the common case, this meant logs look like `some message[]`, when
they should be `some message`.

This also required updating klog since they had a similar bug on their
end.