### PR TITLE
Add support for derived metrics values to monitoring pkg

### DIFF
--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -25,6 +25,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+
 	"istio.io/pkg/log"
 )
 

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -19,9 +19,13 @@ import (
 	"fmt"
 	"sync"
 
+	"go.opencensus.io/metric"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricproducer"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"istio.io/pkg/log"
 )
 
 type (
@@ -56,6 +60,19 @@ type (
 		Register() error
 	}
 
+	// DerivedMetrics can be used to supply values that dynamically derive from internal
+	// state, but are not updated based on any specific event. Their value will be calculated
+	// based on a value func that executes when the metrics are exported.
+	//
+	// At the moment, only a Gauge type is supported.
+	DerivedMetric interface {
+		// Name returns the name value of a DerivedMetric.
+		Name() string
+
+		// Register handles any required setup to ensure metric export.
+		Register() error
+	}
+
 	// Options encode changes to the options passed to a Metric at creation time.
 	Options func(*options)
 
@@ -80,10 +97,14 @@ type (
 var (
 	recordHooks     map[string]RecordHook
 	recordHookMutex sync.RWMutex
+
+	derivedRegistry = metric.NewRegistry()
 )
 
 func init() {
 	recordHooks = make(map[string]RecordHook)
+	// ensures exporters can see any derived metrics
+	metricproducer.GlobalManager().AddProducer(derivedRegistry)
 }
 
 // RegisterRecordHook adds a RecordHook for a given measure.
@@ -146,6 +167,22 @@ func NewGauge(name, description string, opts ...Options) Metric {
 	return newMetric(name, description, view.LastValue(), opts...)
 }
 
+// NewDerivedGauge creates a new Metric with an aggregation type of LastValue that generates the value
+// dynamically according to the provided function. This can be used for values based on querying some
+// state within a system (when event-driven recording is not appropriate).
+// NOTE: Labels not currently supported.
+func NewDerivedGauge(name, description string, valueFn func() float64) DerivedMetric {
+	m, err := derivedRegistry.AddFloat64DerivedGauge(name, metric.WithDescription(description), metric.WithUnit(metricdata.UnitDimensionless))
+	if err != nil {
+		log.Warnf("failed to add metric %q: %v", name, err)
+	}
+	err = m.UpsertEntry(valueFn)
+	if err != nil {
+		log.Warnf("failed to upsert entry for %q: %v", name, err)
+	}
+	return &derivedFloat64Metric{m, name}
+}
+
 // NewDistribution creates a new Metric with an aggregration type of Distribution. This means that the
 // data collected by the Metric will be collected and exported as a histogram, with the specified bounds.
 func NewDistribution(name, description string, bounds []float64, opts ...Options) Metric {
@@ -154,6 +191,21 @@ func NewDistribution(name, description string, bounds []float64, opts ...Options
 
 func newMetric(name, description string, aggregation *view.Aggregation, opts ...Options) Metric {
 	return newFloat64Metric(name, description, aggregation, opts...)
+}
+
+type derivedFloat64Metric struct {
+	*metric.Float64DerivedGauge
+
+	name string
+}
+
+func (d *derivedFloat64Metric) Name() string {
+	return d.name
+}
+
+// no-op
+func (d *derivedFloat64Metric) Register() error {
+	return nil
 }
 
 type float64Metric struct {

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -29,7 +29,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
 )
 
@@ -373,7 +372,6 @@ func (t *testExporter) ExportView(d *view.Data) {
 
 func (t *testExporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
 	for _, m := range data {
-		log.Infof("add data: %q; %#v\n", m.Descriptor.Name, m.TimeSeries)
 		t.metrics[m.Descriptor.Name] = append(t.metrics[m.Descriptor.Name], m.TimeSeries...)
 	}
 	return nil

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -23,10 +23,13 @@ import (
 	"testing"
 	"time"
 
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
+	"istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
 )
 
@@ -147,6 +150,46 @@ func TestGauge(t *testing.T) {
 	)
 	if err != nil {
 		t.Errorf("failure recording gauge values: %v", err)
+	}
+}
+
+func TestDerivedGauge(t *testing.T) {
+	testDerivedGauge := monitoring.NewDerivedGauge(
+		"test_derived_gauge",
+		"Testing derived gauae functionality",
+		func() float64 {
+			return 17.76
+		},
+	)
+	exp := &testExporter{rows: make(map[string][]*view.Row), metrics: make(map[string][]*metricdata.TimeSeries)}
+
+	reader := metricexport.NewReader()
+
+	err := retry(
+		func() error {
+			reader.ReadAndExport(exp)
+
+			if len(exp.metrics[testDerivedGauge.Name()]) < 1 {
+				return errors.New("no values recorded for gauge, want 1")
+			}
+
+			found := false
+			for _, ts := range exp.metrics[testDerivedGauge.Name()] {
+				for _, point := range ts.Points {
+					if got, want := point.Value.(float64), 17.76; got != want {
+						return fmt.Errorf("unexpected value for gauge %q found; got %f; expected %f", testDerivedGauge.Name(), got, want)
+					}
+					found = true
+				}
+			}
+			if !found {
+				return fmt.Errorf("expected value for gauge %q not found; expected 17.76", testDerivedGauge.Name())
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Errorf("failure recording derived gauge values: %v", err)
 	}
 }
 
@@ -313,6 +356,7 @@ type testExporter struct {
 	sync.Mutex
 
 	rows        map[string][]*view.Row
+	metrics     map[string][]*metricdata.TimeSeries
 	invalidTags bool
 }
 
@@ -325,6 +369,14 @@ func (t *testExporter) ExportView(d *view.Data) {
 	}
 	t.rows[d.View.Name] = append(t.rows[d.View.Name], d.Rows...)
 	t.Unlock()
+}
+
+func (t *testExporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	for _, m := range data {
+		log.Infof("add data: %q; %#v\n", m.Descriptor.Name, m.TimeSeries)
+		t.metrics[m.Descriptor.Name] = append(t.metrics[m.Descriptor.Name], m.TimeSeries...)
+	}
+	return nil
 }
 
 func findTagWithValue(key, value string, tags []tag.Tag) bool {


### PR DESCRIPTION
This adds the initial capability to have dynamic metric values for Istio components (only gauges w/o labels supported at this time). This is intended to better support metrics such as `uptime` in a manner that isn't tied to a specific exporter (like Prometheus).