### PR TITLE
add transforming exporter for monitoring transformations

### DIFF
--- a/monitoring/transforming_exporter.go
+++ b/monitoring/transforming_exporter.go
@@ -1,0 +1,193 @@
+// Copyright 2021 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+)
+
+type MetricOperation func(operations)
+
+type operations map[string]metricOperation
+
+type metricOperation struct {
+	newName       string
+	labelNameMap  map[string]string
+	labelValueMap map[string]LabelValueMapperFn
+	constLabels   map[string]string
+	dropLabels    []string
+}
+
+func RenameMetric(metric, newName string) MetricOperation {
+	return func(ops operations) {
+		op, found := ops[metric]
+		if !found {
+			mop := makeMetricOperation()
+			mop.newName = newName
+			ops[metric] = mop
+			return
+		}
+		op.newName = newName
+	}
+}
+
+func RenameLabels(metric string, labelMap map[string]string) MetricOperation {
+	return func(ops operations) {
+		op, found := ops[metric]
+		if !found {
+			mop := makeMetricOperation()
+			mop.labelNameMap = labelMap
+			ops[metric] = mop
+			return
+		}
+		for k, v := range labelMap {
+			op.labelNameMap[k] = v
+		}
+	}
+}
+
+type LabelValueMapperFn func(in string) string
+
+func MapLabelValues(metric string, mapFns map[string]LabelValueMapperFn) MetricOperation {
+	return func(ops operations) {
+		op, found := ops[metric]
+		if !found {
+			mop := makeMetricOperation()
+			mop.labelValueMap = mapFns
+			ops[metric] = mop
+			return
+		}
+		for k, v := range mapFns {
+			op.labelValueMap[k] = v
+		}
+	}
+}
+
+func AddConstLabelValues(metric string, labels map[string]string) MetricOperation {
+	return func(ops operations) {
+		op, found := ops[metric]
+		if !found {
+			mop := makeMetricOperation()
+			mop.constLabels = labels
+			ops[metric] = mop
+			return
+		}
+		for k, v := range labels {
+			op.constLabels[k] = v
+		}
+	}
+}
+
+func DropLabels(metric string, toDrop []string) MetricOperation {
+	return func(ops operations) {
+		op, found := ops[metric]
+		if !found {
+			mop := makeMetricOperation()
+			mop.dropLabels = toDrop
+			ops[metric] = mop
+			return
+		}
+		op.dropLabels = append(op.dropLabels, toDrop...)
+	}
+}
+
+func makeMetricOperation() metricOperation {
+	return metricOperation{
+		labelNameMap:  make(map[string]string),
+		labelValueMap: make(map[string]LabelValueMapperFn),
+		constLabels:   make(map[string]string),
+		dropLabels:    make([]string, 0),
+	}
+}
+
+type transformingExporter struct {
+	baseExporter     metricexport.Exporter
+	metricOperations operations
+	dropUnmodified   bool
+}
+
+func (te *transformingExporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	newData := make([]*metricdata.Metric, 0, len(data))
+	for _, datum := range data {
+		op, found := te.metricOperations[datum.Descriptor.Name]
+		if !found {
+			if !te.dropUnmodified {
+				newData = append(newData, datum)
+			}
+			continue
+		}
+		newMetric := &metricdata.Metric{Resource: datum.Resource}
+		newMetric.Descriptor = metricdata.Descriptor{
+			Name:        datum.Descriptor.Name,
+			Description: datum.Descriptor.Description,
+			Unit:        datum.Descriptor.Unit,
+			Type:        datum.Descriptor.Type,
+			LabelKeys:   datum.Descriptor.LabelKeys,
+		}
+		newMetric.TimeSeries = datum.TimeSeries
+		if op.newName != "" {
+			newMetric.Descriptor.Name = op.newName
+		}
+		if len(op.labelNameMap) > 0 || len(op.constLabels) > 0 {
+			newKeys := make([]metricdata.LabelKey, 0, len(datum.Descriptor.LabelKeys))
+			for _, key := range datum.Descriptor.LabelKeys {
+				newKey, found := op.labelNameMap[key.Key]
+				if found {
+					newKeys = append(newKeys, metricdata.LabelKey{Key: newKey, Description: key.Description})
+				} else {
+					newKeys = append(newKeys, key)
+				}
+			}
+			for k, _ := range op.constLabels {
+				newKeys = append(newKeys, metricdata.LabelKey{Key: k})
+			}
+			newMetric.Descriptor.LabelKeys = newKeys
+		}
+		if len(op.labelValueMap) > 0 || len(op.constLabels) > 0 {
+			newTimeSeries := make([]*metricdata.TimeSeries, 0, len(datum.TimeSeries))
+			for _, ts := range datum.TimeSeries {
+				newTS := &metricdata.TimeSeries{StartTime: ts.StartTime, Points: ts.Points, LabelValues: make([]metricdata.LabelValue, 0, len(ts.LabelValues))}
+				for i, lv := range ts.LabelValues {
+					fn, found := op.labelValueMap[datum.Descriptor.LabelKeys[i].Key]
+					if found {
+						newTS.LabelValues = append(newTS.LabelValues, metricdata.LabelValue{Value: fn(lv.Value), Present: lv.Present})
+					} else {
+						newTS.LabelValues = append(newTS.LabelValues, lv)
+					}
+				}
+				for _, v := range op.constLabels {
+					newTS.LabelValues = append(newTS.LabelValues, metricdata.LabelValue{Value: v, Present: true})
+				}
+				newTimeSeries = append(newTimeSeries, newTS)
+			}
+			newMetric.TimeSeries = newTimeSeries
+		}
+
+		newData = append(newData, newMetric)
+	}
+
+	return te.baseExporter.ExportMetrics(ctx, newData)
+}
+
+func NewTransformingExporter(baseExporter metricexport.Exporter, dropUnmodified bool, ops ...MetricOperation) metricexport.Exporter {
+	o := make(operations)
+	for _, operation := range ops {
+		operation(o)
+	}
+	return &transformingExporter{baseExporter: baseExporter, dropUnmodified: dropUnmodified, metricOperations: o}
+}

--- a/monitoring/transforming_exporter_test.go
+++ b/monitoring/transforming_exporter_test.go
@@ -1,0 +1,142 @@
+// Copyright 2021 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+	"go.opencensus.io/stats/view"
+	"istio.io/pkg/monitoring"
+)
+
+func TestTransformExporter(t *testing.T) {
+	exp := &testExporter{rows: make(map[string][]*view.Row), metrics: make(map[string][]*metricdata.Metric)}
+
+	testSum.With(name.Value("foo"), kind.Value("bar")).Increment()
+	goofySum.With(name.Value("baz")).Record(45)
+	goofySum.With(name.Value("baz")).Decrement()
+
+	testGauge.Record(42)
+	testGauge.Record(77)
+
+	testDerivedGauge := monitoring.NewDerivedGauge(
+		"test_derived_gauge",
+		"Testing derived gauae functionality",
+		func() float64 {
+			return 17.76
+		},
+	)
+
+	reader := metricexport.NewReader()
+
+	tranformingExporter := monitoring.NewTransformingExporter(exp,
+		true, /* drop unmodified */
+		monitoring.RenameMetric(testDerivedGauge.Name(), "funtime_happy_gauge"),
+		monitoring.RenameLabels(testSum.Name(), map[string]string{"name": "aka"}),
+		monitoring.MapLabelValues(testSum.Name(), map[string]monitoring.LabelValueMapperFn{
+			"kind": func(in string) string { return "serious" },
+		}),
+		monitoring.AddConstLabelValues(testDerivedGauge.Name(), map[string]string{"version": "v1.2.3"}),
+	)
+
+	err := retry(
+		func() error {
+			reader.ReadAndExport(tranformingExporter)
+
+			// check dropped
+			if len(exp.metrics[testGauge.Name()]) != 0 {
+				return fmt.Errorf("metric recorded for unmodifed gauge %q (that should have been dropped)", testGauge.Name())
+			}
+
+			// check gauge
+			if len(exp.metrics["funtime_happy_gauge"]) < 1 {
+				return fmt.Errorf("no metric recorded for name-mapped gauge %q", testDerivedGauge.Name())
+			}
+			for _, metric := range exp.metrics["funtime_happy_gauge"] {
+				for _, ts := range metric.TimeSeries {
+					for _, point := range ts.Points {
+						if got, want := point.Value.(float64), 17.76; got != want {
+							return fmt.Errorf("unexpected value for gauge; got %f, want %f", got, want)
+						}
+					}
+				}
+			}
+
+			// check label renaming
+			if len(exp.metrics[testSum.Name()]) < 1 {
+				return fmt.Errorf("no metric recorded for dimensioned sum: %#v", exp.metrics)
+			}
+			for _, metric := range exp.metrics[testSum.Name()] {
+				found := false
+				for _, key := range metric.Descriptor.LabelKeys {
+					if key.Key == "aka" {
+						found = true
+					}
+				}
+				if !found {
+					return fmt.Errorf("renamed label not found")
+				}
+			}
+
+			// check label value mapping
+			for _, metric := range exp.metrics[testSum.Name()] {
+				for _, ts := range metric.TimeSeries {
+					found := false
+					for _, lv := range ts.LabelValues {
+						if lv.Value == "serious" {
+							found = true
+						}
+					}
+					if !found {
+						return fmt.Errorf("mapped label value not found")
+					}
+				}
+			}
+
+			// check add const labels
+			for _, metric := range exp.metrics["funtime_happy_gauge"] {
+				found := false
+				for _, lk := range metric.Descriptor.LabelKeys {
+					if lk.Key == "version" {
+						found = true
+					}
+				}
+				if !found {
+					return errors.New("could not find added const label key")
+				}
+				for _, ts := range metric.TimeSeries {
+					found := false
+					for _, lv := range ts.LabelValues {
+						if lv.Value == "v1.2.3" {
+							found = true
+						}
+					}
+					if !found {
+						return errors.New("could not find added const label value")
+					}
+				}
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		t.Fatalf("failure: %v", err)
+	}
+}


### PR DESCRIPTION
WIP: Draft PR for comments / design discussions. Code in barely workable state; needs clean up.

This would add a transforming exporter for metrics managed by the `monitoring` package. This would provide an alternative to `RecordHooks` while also providing a cross-exporter mechanism for getting access to OC metric data (in addition to OC stats). This would allow export manipulation of metrics from `NewDerivedGauge`, for instance.