### PR TITLE
add support for quota project to teeToStackdriver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	google.golang.org/api v0.38.0
 	google.golang.org/genproto v0.0.0-20210218151259-fe80b386bf06
 	google.golang.org/grpc v1.35.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect

--- a/log/config.go
+++ b/log/config.go
@@ -335,11 +335,23 @@ func Configure(options *Options) error {
 
 	if options.teeToStackdriver {
 		// build stackdriver core.
-		core, err = teeToStackdriver(core, options.stackdriverTargetProject, options.stackdriverLogName, options.stackdriverResource)
+		core, err =
+			teeToStackdriver(
+				core,
+				options.stackdriverTargetProject,
+				options.stackdriverQuotaProject,
+				options.stackdriverLogName,
+				options.stackdriverResource)
 		if err != nil {
 			return err
 		}
-		captureCore, err = teeToStackdriver(captureCore, options.stackdriverTargetProject, options.stackdriverLogName, options.stackdriverResource)
+		captureCore, err =
+			teeToStackdriver(
+				captureCore,
+				options.stackdriverTargetProject,
+				options.stackdriverQuotaProject,
+				options.stackdriverLogName,
+				options.stackdriverResource)
 		if err != nil {
 			return err
 		}

--- a/log/options.go
+++ b/log/options.go
@@ -125,6 +125,7 @@ type Options struct {
 	useStackdriverFormat     bool
 	teeToStackdriver         bool
 	stackdriverTargetProject string
+	stackdriverQuotaProject  string
 	stackdriverLogName       string
 	stackdriverResource      *monitoredres.MonitoredResource
 }
@@ -154,6 +155,17 @@ func (o *Options) WithStackdriverLoggingFormat() *Options {
 func (o *Options) WithTeeToStackdriver(project, logName string, mr *monitoredres.MonitoredResource) *Options {
 	o.teeToStackdriver = true
 	o.stackdriverTargetProject = project
+	o.stackdriverQuotaProject = project
+	o.stackdriverLogName = logName
+	o.stackdriverResource = mr
+	return o
+}
+
+// WithTeeToStackdriver configures a parallel logging pipeline that writes logs to the Google Cloud Logging API.
+func (o *Options) WithTeeToStackdriverWithQuotaProject(project, quotaProject, logName string, mr *monitoredres.MonitoredResource) *Options {
+	o.teeToStackdriver = true
+	o.stackdriverTargetProject = project
+	o.stackdriverQuotaProject = quotaProject
 	o.stackdriverLogName = logName
 	o.stackdriverResource = mr
 	return o

--- a/log/stackdriver.go
+++ b/log/stackdriver.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
@@ -63,12 +64,12 @@ type stackdriverCore struct {
 }
 
 // teeToStackdriver returns a zapcore.Core that writes entries to both the provided core and to Stackdriver.
-func teeToStackdriver(baseCore zapcore.Core, project, logName string, mr *monitoredres.MonitoredResource) (zapcore.Core, error) {
+func teeToStackdriver(baseCore zapcore.Core, project, quotaProject, logName string, mr *monitoredres.MonitoredResource) (zapcore.Core, error) {
 	if project == "" {
 		return nil, errors.New("a project must be provided for stackdriver export")
 	}
 
-	client, err := logging.NewClient(context.Background(), project)
+	client, err := logging.NewClient(context.Background(), project, option.WithQuotaProject(quotaProject))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This will support adding QuotaProjects (as distinct from target projects) for stackdriver logging.