### PR TITLE
Add support for Close to logging package

### DIFF
--- a/log/config.go
+++ b/log/config.go
@@ -330,7 +330,7 @@ func Configure(options *Options) error {
 		return err
 	}
 
-	closeFns := make([]func() error, 0, 0)
+	closeFns := make([]func() error, 0)
 
 	if options.teeToStackdriver {
 		var closeFn, captureCloseFn func() error
@@ -383,7 +383,8 @@ func Configure(options *Options) error {
 		exitProcess: os.Exit,
 		errorSink:   errSink,
 		close: func() error {
-			core.Sync()
+			// best-effort to sync
+			core.Sync() // nolint: errcheck
 			for _, f := range closeFns {
 				if err := f(); err != nil {
 					return err


### PR DESCRIPTION
When `TeeToStackdriver` type logging is requested, clients can be established to handle the buffering and pushing of logs to the Cloud Logging service. However, there is no existing way to close these clients. This can lead to leaks, as detected by leak tests.

This PR seeks to add a way to ensure those clients can be closed appropriately.