### PR TITLE
Optimize open-census usage

### DIFF
--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -111,7 +111,7 @@ func TestSum(t *testing.T) {
 						testSumVal = sd.Value
 					}
 				} else {
-					return fmt.Errorf("unknown row in results: %v", r)
+					return fmt.Errorf("unknown row in results: %+v", r)
 				}
 			}
 			if got, want := goofySumVal, 44.0; got != want {
@@ -127,7 +127,7 @@ func TestSum(t *testing.T) {
 						int64SumVal = int64(sd.Value)
 					}
 				} else {
-					return fmt.Errorf("unknown row in results: %v", r)
+					return fmt.Errorf("unknown row in results: %+v", r)
 				}
 			}
 			if got, want := int64SumVal, int64(21); got != want {
@@ -457,4 +457,14 @@ func (r *testRecordHook) OnRecordFloat64Measure(f *stats.Float64Measure, tags []
 		return
 	}
 	hookSum.With(name.Value(v)).Record(value)
+}
+
+func BenchmarkCounter(b *testing.B) {
+	exp := &testExporter{rows: make(map[string][]*view.Row)}
+	view.RegisterExporter(exp)
+	view.SetReportingPeriod(1 * time.Millisecond)
+
+	for n := 0; n < b.N; n++ {
+		int64Sum.Increment()
+	}
 }


### PR DESCRIPTION
See https://github.com/census-instrumentation/opencensus-go/issues/1265

Benchmark:
```
name       old time/op    new time/op    delta
Counter-6     713ns ± 8%     680ns ± 3%   -4.63%  (p=0.006 n=10+9)

name       old alloc/op   new alloc/op   delta
Counter-6      205B ± 0%      173B ± 0%  -15.63%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
Counter-6      6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
```

This is not *that* much faster, but once my OC PRs merge we can take advantage of more optimizations this way, bringing us down to:
```
name       old time/op    new time/op    delta
Counter-6     713ns ± 8%     618ns ± 6%  -13.35%  (p=0.000 n=10+9)

name       old alloc/op   new alloc/op   delta
Counter-6      205B ± 0%       68B ± 1%  -66.59%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
Counter-6      6.00 ± 0%      3.00 ± 0%  -50.00%  (p=0.000 n=10+10)
``