### PR TITLE
Add basic label support for derived metrics

### DIFF
--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -269,14 +269,18 @@ func (d *derivedFloat64Metric) Register() error {
 
 func (d *derivedFloat64Metric) ValueFrom(valueFn func() float64, labelValues ...string) {
 	if len(labelValues) == 0 {
-		d.base.UpsertEntry(valueFn)
+		if err := d.base.UpsertEntry(valueFn); err != nil {
+			log.Errorf("failed to add value for derived metric %q: %v", d.name, err)
+		}
 		return
 	}
 	lv := make([]metricdata.LabelValue, 0, len(labelValues))
 	for _, l := range labelValues {
 		lv = append(lv, metricdata.NewLabelValue(l))
 	}
-	d.base.UpsertEntry(valueFn, lv...)
+	if err := d.base.UpsertEntry(valueFn, lv...); err != nil {
+		log.Errorf("failed to add value for derived metric %q: %v", d.name, err)
+	}
 }
 
 type float64Metric struct {


### PR DESCRIPTION
This is a proposal for a mechanism to support derived gauges that take label dimensions. This would allow the creation of a derived gauge that can be dimensioned with differing derivations of value. For instance, cert expiry metrics could be created with differing values based on the cert name or trust domain, etc., but with the same overall metric name.

I'm looking for feedback on overall approach and naming.