### PR TITLE
change defaultRotationMaxSize

### DIFF
--- a/log/options.go
+++ b/log/options.go
@@ -31,7 +31,7 @@ const (
 	defaultOutputPath         = "stdout"
 	defaultErrorOutputPath    = "stderr"
 	defaultRotationMaxAge     = 30
-	defaultRotationMaxSize    = 100 * 1024 * 1024
+	defaultRotationMaxSize    = 100
 	defaultRotationMaxBackups = 1000
 )
 


### PR DESCRIPTION
RotationMaxSize is the maximum size in megabytes of a log file 