### PR TITLE
Fix inconsistent proxy version displaying

### DIFF
--- a/version/cobra.go
+++ b/version/cobra.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -178,9 +179,14 @@ func renderProxyVersions(pinfos *[]ProxyInfo) string {
 		ids := versions[pinfo.IstioVersion]
 		versions[pinfo.IstioVersion] = append(ids, pinfo.ID)
 	}
+	sortedVersions := make([]string, 0)
+	for v := range versions {
+		sortedVersions = append(sortedVersions, v)
+	}
+	sort.Strings(sortedVersions)
 	counts := []string{}
-	for ver, ids := range versions {
-		counts = append(counts, fmt.Sprintf("%s (%d proxies)", ver, len(ids)))
+	for _, ver := range sortedVersions {
+		counts = append(counts, fmt.Sprintf("%s (%d proxies)", ver, len(versions[ver])))
 	}
 	return strings.Join(counts, ", ")
 }


### PR DESCRIPTION
Using map leads to random order of proxy versions displayed when using `istioctl version`, this makes the order always be consistent. Small version first like:
```
client version: 1.16-dev
control plane version: 1.16
data plane version: 1.14.0 (13 proxies), 1.16-alpha.e1f63e8ce82e3bad28c2bb0a87f4bc7ffefac1b9 (1 proxies)
```