### PR TITLE
Add buildOS to build info

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -29,6 +29,7 @@ var (
 	buildStatus      = "unknown"
 	buildTag         = "unknown"
 	buildHub         = "unknown"
+	buildOS          = "unknown"
 	buildArch        = "unknown"
 )
 
@@ -56,10 +57,11 @@ type ProxyInfo struct {
 	IstioVersion string
 }
 
-// DockerBuildInfo contains and exposes Hub: buildHub, Tag: buildVersion and Arch: buildArch
+// DockerBuildInfo contains and exposes Hub: buildHub, Tag: buildVersion, OS: buildOS, and Arch: buildArch
 type DockerBuildInfo struct {
 	Hub  string
 	Tag  string
+	OS   string
 	Arch string
 }
 
@@ -138,6 +140,7 @@ func init() {
 	DockerInfo = DockerBuildInfo{
 		Hub:  buildHub,
 		Tag:  buildVersion,
+		OS:   buildOS,
 		Arch: buildArch,
 	}
 }


### PR DESCRIPTION
From https://github.com/istio/common-files/pull/687#discussion_r998260529, the OS should be added as well. An alternative way is to change the `buildArch` name to something like `buildPlatform` to print the info like `linux/amd64`. I think the former one will be easier to use.