### PR TITLE
chore(deps): use only sigs.k8s.io/yaml to handle yaml

### DIFF
--- a/collateral/control.go
+++ b/collateral/control.go
@@ -43,7 +43,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/collateral/metrics"
 	"istio.io/pkg/env"

--- a/ctrlz/topics/collection.go
+++ b/ctrlz/topics/collection.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/ctrlz/fw"
 	"istio.io/pkg/ctrlz/topics/assets"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55
 	google.golang.org/grpc v1.50.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
-	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.4.0
 	k8s.io/klog/v2 v2.80.1
 	sigs.k8s.io/yaml v1.3.0
@@ -53,5 +52,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Use `sigs.k8s.io/yaml` to handle yaml as it was already the most used library and is also based on `gopkg.in/yaml.v2`

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>