### PR TITLE
tests: fix slow tests

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -126,7 +126,7 @@ func testCacheConcurrent(c Cache, t *testing.T) {
 	workers := runtime.NumCPU()
 	wg.Add(workers)
 
-	const numIters = 100000
+	const numIters = 10000
 	for i := 0; i < workers; i++ {
 		workerNum := i
 		go func() {

--- a/filewatcher/filewatcher_test.go
+++ b/filewatcher/filewatcher_test.go
@@ -17,14 +17,12 @@ package filewatcher
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/fsnotify/fsnotify"
 	. "github.com/onsi/gomega"
@@ -386,159 +384,4 @@ func TestBogusRemove(t *testing.T) {
 	}
 
 	_ = w.Close()
-}
-
-type churnFile struct {
-	file        string
-	cleanupFile func()
-	eventDoneCh chan struct{}
-}
-
-func (c *churnFile) active() bool {
-	return c.cleanupFile != nil
-}
-
-func (c *churnFile) create(w FileWatcher) error {
-	if c.active() {
-		panic("File is currently active")
-	}
-	f, cl, err := newWatchFileImpl()
-	if err != nil {
-		return err
-	}
-
-	if err = w.Add(f); err != nil {
-		cl()
-		return err
-	}
-
-	events := w.Events(f)
-	errors := w.Errors(f)
-	eventDoneCh := make(chan struct{})
-
-	c.eventDoneCh = eventDoneCh
-	c.file = f
-	c.cleanupFile = cl
-
-	go func() {
-		// sporadically read events
-		// nolint: gosec
-		// test only code
-		for {
-			<-time.After(time.Millisecond * time.Duration(rand.Int31n(5)))
-			select {
-			case <-eventDoneCh:
-				return
-			case <-events: // read and discard events
-			case <-errors:
-			}
-		}
-	}()
-
-	return nil
-}
-
-// nolint: gosec
-// test only code
-func changeFileContents(file string) {
-	l := rand.Int31n(4 * 1024)
-	b := make([]byte, l)
-	for i := 0; i < int(l); i++ {
-		b[i] = byte(rand.Int31n(255))
-	}
-
-	_ = os.WriteFile(file, b, 0o777)
-}
-
-func (c *churnFile) modify() {
-	if !c.active() {
-		panic("file is not active")
-	}
-	changeFileContents(c.file)
-}
-
-func (c *churnFile) remove(w FileWatcher) error {
-	if !c.active() {
-		panic("file is not active")
-	}
-	close(c.eventDoneCh)
-	err := w.Remove(c.file)
-	c.cleanupFile()
-
-	c.file = ""
-	c.cleanupFile = nil
-	c.eventDoneCh = nil
-
-	return err
-}
-
-func TestChurn(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	duration := time.Second * 5
-	workers := 5
-	filesPerWorker := 15
-
-	w := NewWatcher()
-	defer func() { _ = w.Close() }()
-
-	done := make(chan struct{})
-	go func() {
-		<-time.After(duration)
-		close(done)
-	}()
-
-	// create a bunch of workers and perform add/modify operations
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-			files := make([]*churnFile, filesPerWorker)
-			for j := 0; j < filesPerWorker; j++ {
-				files[j] = &churnFile{}
-			}
-
-			defer func() {
-				for _, e := range files {
-					if e.active() {
-						_ = e.remove(w)
-					}
-				}
-			}()
-
-			// nolint: gosec
-			// test only code
-			for {
-				select {
-				case <-done:
-					return
-				default:
-				}
-
-				f := files[rand.Int31n(int32(filesPerWorker))]
-				switch rand.Int31n(2) {
-				case 0: // modify or create
-					if f.active() {
-						f.modify()
-					} else {
-						err := f.create(w)
-						g.Expect(err).To(BeNil())
-					}
-
-				case 1: // create or delete
-					if f.active() {
-						err := f.remove(w)
-						g.Expect(err).To(BeNil())
-					} else {
-						err := f.create(w)
-						g.Expect(err).To(BeNil())
-					}
-				}
-			}
-		}()
-	}
-
-	wg.Wait()
 }

--- a/log/config_test.go
+++ b/log/config_test.go
@@ -287,23 +287,18 @@ func TestRotateMaxBackups(t *testing.T) {
 			log.Println(line)
 		}
 	}
+	Sync()
 
-	// log rotation happens asynchronously and there's no way to synchronize with it,
-	// so we poll
-	for i := 0; i < 100009; i++ {
-		rd, err := os.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("Unable to read dir: %v", err)
-		}
-
-		if len(rd) == o.RotationMaxBackups+1 {
-			// perfect, we're done
-			return
-		}
-
-		// try again in a bit
-		time.Sleep(10 * time.Millisecond)
+	rd, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Unable to read dir: %v", err)
 	}
+
+	if len(rd) == o.RotationMaxBackups+1 {
+		// perfect, we're done
+		return
+	}
+
 	t.Errorf("Expecting at most %d backup logs", o.RotationMaxBackups)
 }
 


### PR DESCRIPTION
Before merging into istio/istio, make sure tests are up to par.

Mostly just standard fixing slow Sleep() type tests, but TestChurn is
100% removed since it is a load test which isn't really appropriate for
unit tests. Worse, it fails on most machines since it opens a ton of
files.
